### PR TITLE
Malicious smart contract bot updates

### DIFF
--- a/malicious-smart-contract-ml-v3-py/.gitignore
+++ b/malicious-smart-contract-ml-v3-py/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .pytest_cache
 malicious_non_token_model_11_05_22.joblib
 src/luabase_constants.py
+publish.log

--- a/malicious-smart-contract-ml-v3-py/publish.log
+++ b/malicious-smart-contract-ml-v3-py/publish.log
@@ -1,2 +1,0 @@
-Tue, 08 Nov 2022 16:23:22 GMT: successfully pushed image with reference bafybeie5rpehnsbhdktlbl666epfnsraytejnglh3sm5cgxxm4ojwii65i@sha256:7c3e885382b7625a3581cc5e6883e8af20e6175bf8cc64d82d542c04318c8169
-Fri, 11 Nov 2022 22:09:13 GMT: successfully pushed image with reference bafybeid6hiyoztnbj3mpqvcbkq4wrbdnv2aqtagn3j7bkrq76mql2zwzfe@sha256:e8ff77a1b9949861aae3deddf9c7e341345a30665faa149a11c0213e6c54e1d9

--- a/malicious-smart-contract-ml-v3-py/src/agent.py
+++ b/malicious-smart-contract-ml-v3-py/src/agent.py
@@ -80,6 +80,7 @@ def detect_malicious_contract_tx(
                         trace.action.from_,
                         created_contract_address,
                         creation_bytecode,
+                        error=error,
                     )
                 )
     else:  # Trace isn't supported, To improve coverage, process contract creations from EOAs.
@@ -101,7 +102,9 @@ def detect_malicious_contract_tx(
     return all_findings
 
 
-def detect_malicious_contract(w3, from_, created_contract_address, code) -> list:
+def detect_malicious_contract(
+    w3, from_, created_contract_address, code, error=None
+) -> list:
     findings = []
 
     if created_contract_address is not None:
@@ -131,6 +134,7 @@ def detect_malicious_contract(w3, from_, created_contract_address, code) -> list
                         model_score,
                         MODEL_THRESHOLD,
                         anomaly_score,
+                        error=error,
                     )
                 )
 

--- a/malicious-smart-contract-ml-v3-py/src/constants.py
+++ b/malicious-smart-contract-ml-v3-py/src/constants.py
@@ -30,15 +30,15 @@ PROXY_SIGHASHES = {"0x5c60da1b", "0x3659cfe6", "0x4f1ef286", "0x8f283970"}
 CHAIN_ID_METADATA_MAPPING = {
     1: (
         "ethereum",
-        147.5,
-        32_713,
-    ),  # 147.5 avg of last week of Oct, 2022, 32_713 count of new contracts in 24-hr time frame.
-    137: ("polygon", 50, 6_681),  # TODO: Update alert_count
-    56: ("binance", 600, 128_000),  # TODO: Update alert_count, contract_deployment
-    43114: ("avalanche", 10, 432),  # TODO: Update alert_count
-    42161: ("arbitrum", 62, 14_000),  # TODO: Update alert_count, contract_deployment
-    10: ("optimism", 44, 9_800),  # TODO: Update alert_count, contract_deployment
-    250: ("fantom", 1000, 345_486),  # TODO: Update alert_count
+        172,  # alert_count
+        32_713,  # contract deployment
+    ),  # alert_count = avg of last 24 hrs of Nov 14, 2022.
+    137: ("polygon", 194, 6_681),
+    56: ("binance", 182, 299_458),
+    43114: ("avalanche", 23, 432),
+    42161: ("arbitrum", 302, 9_800),
+    10: ("optimism", 15, 1_651),
+    250: ("fantom", 7, 345_486),
 }
 
 LUABASE_SUPPORTED_CHAINS = {1, 137, 43114, 250}

--- a/malicious-smart-contract-ml-v3-py/src/findings.py
+++ b/malicious-smart-contract-ml-v3-py/src/findings.py
@@ -10,6 +10,7 @@ class MaliciousTokenContractFindings:
         model_score: float,
         model_threshold: float,
         anomaly_score: float,
+        error: str = None,
     ) -> Finding:
         metadata = {
             "address_contained_in_created_contract_" + str(i): address
@@ -22,11 +23,16 @@ class MaliciousTokenContractFindings:
         metadata["model_score"] = str(model_score)
         metadata["model_threshold"] = str(model_threshold)
         metadata["anomaly_score"] = anomaly_score
+        description = (
+            f"{from_address} created contract {contract_address}"
+            if error is None
+            else f"{from_address} failed to create contract {contract_address} with err: {error}"
+        )
 
         return Finding(
             {
                 "name": "Suspicious Contract Creation",
-                "description": f"{from_address} created contract {contract_address}",
+                "description": description,
                 "alert_id": "SUSPICIOUS-CONTRACT-CREATION",
                 "type": FindingType.Suspicious,
                 "severity": FindingSeverity.High,


### PR DESCRIPTION
- replace 6 chain's default alert count and deployment count guesstimates by actual counts from Luabase and Dune
- Include error message for failed contract creations in the alert description