### PR TITLE
[Forta 421] Malicious Account Funding Update

### DIFF
--- a/malicious-account-funding-py/requirements.txt
+++ b/malicious-account-funding-py/requirements.txt
@@ -1,5 +1,3 @@
 forta_agent>=0.1.5
 setuptools>=61.3.1
-pandas>=1.4.2
 requests>=2.27.1
-python-dotenv>=0.16.0

--- a/malicious-account-funding-py/requirements.txt
+++ b/malicious-account-funding-py/requirements.txt
@@ -1,3 +1,4 @@
-forta_agent>=0.1.5
+forta_agent>=0.1.9
 setuptools>=61.3.1
 requests>=2.27.1
+expiring-dict>=1.1.0

--- a/malicious-account-funding-py/src/agent.py
+++ b/malicious-account-funding-py/src/agent.py
@@ -1,11 +1,12 @@
+from datetime import datetime
 import logging
 import sys
 
+from expiring_dict import ExpiringDict
 from functools import lru_cache
-import requests
-
 import forta_agent
 from forta_agent import get_json_rpc_url
+import requests
 from web3 import Web3
 
 from src.findings import MaliciousAccountFundingFinding
@@ -28,6 +29,8 @@ CHAIN_SOURCE_IDS_MAPPING = {
     137: ["polygon-tags"],  # Polygon
     250: ["fantom-tags"],  # Fantom
 }
+GLOBAL_TOTAL_TX_COUNTER = ExpiringDict(ttl=86_400)
+BOT_ID = "0x2df302b07030b5ff8a17c91f36b08f9e2b1e54853094e2513f7cda734cf68a46"
 
 
 @lru_cache(maxsize=1_000_000)
@@ -47,17 +50,52 @@ def is_malicious_account(chain_id: int, address: str) -> str:
     return wallet_tag
 
 
+def update_tx_counter(date_hour: str):
+    # Total number of transactions in the last 24 hrs
+    global GLOBAL_TOTAL_TX_COUNTER
+    GLOBAL_TOTAL_TX_COUNTER[date_hour] = GLOBAL_TOTAL_TX_COUNTER.get(date_hour, 0) + 1
+
+
+def alert_count(chain_id) -> int:
+    alert_stats_url = (
+        f"https://api.forta.network/stats/bot/{BOT_ID}/alerts?chainId={chain_id}"
+    )
+    alert_count = 0
+    try:
+        result = requests.get(alert_stats_url).json()
+        alert_count = result["total"]["count"]
+    except Exception as err:
+        logging.error(f"Error obtaining alert counts: {err}")
+
+    return alert_count
+
+
+def calculate_anomaly_score(chain_id: int) -> float:
+    total_alerts = alert_count(chain_id)
+    total_tx_count = sum(GLOBAL_TOTAL_TX_COUNTER.values())
+    return total_alerts / total_tx_count
+
+
 def detect_funding(
     w3, transaction_event: forta_agent.transaction_event.TransactionEvent
 ) -> list:
     findings = []
 
+    date_time = datetime.now()
+    date_hour = date_time.strftime("%d/%m/%Y %H:00:00")
+    update_tx_counter(date_hour)
     from_ = transaction_event.transaction.from_.lower()
     malicious_account = is_malicious_account(w3.eth.chain_id, from_)
+    anomaly_score = calculate_anomaly_score(w3.eth.chain_id)
+
     if transaction_event.transaction.value > 0 and malicious_account is not None:
         findings.append(
             MaliciousAccountFundingFinding.funding(
-                transaction_event.transaction.to, from_, malicious_account
+                transaction_event.hash,
+                transaction_event.transaction.to,
+                from_,
+                malicious_account,
+                anomaly_score,
             )
         )
 

--- a/malicious-account-funding-py/src/agent.py
+++ b/malicious-account-funding-py/src/agent.py
@@ -1,19 +1,15 @@
 import logging
 import sys
+
+from functools import lru_cache
 import requests
-import pandas as pd
 
 import forta_agent
 from forta_agent import get_json_rpc_url
 from web3 import Web3
 
-from src.constants import LUABASE_QUERY
 from src.findings import MaliciousAccountFundingFinding
 
-import os
-
-from dotenv import load_dotenv
-load_dotenv()
 
 web3 = Web3(Web3.HTTPProvider(get_json_rpc_url()))
 
@@ -22,65 +18,56 @@ root.setLevel(logging.INFO)
 
 handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 handler.setFormatter(formatter)
 root.addHandler(handler)
 
-KNOWN_MALICIOUS_ACCOUNTS = dict()  # lower case address -> tag
+
+CHAIN_SOURCE_IDS_MAPPING = {
+    1: ["etherscan", "etherscan-tags"],  # Ethereum
+    137: ["polygon-tags"],  # Polygon
+    250: ["fantom-tags"],  # Fantom
+}
 
 
-def initialize():
-    """
-    this function initializes the state variables that are tracked across tx and blocks
-    it is called from test to reset state between tests
-    """
-    global KNOWN_MALICIOUS_ACCOUNTS
-    KNOWN_MALICIOUS_ACCOUNTS = dict()
+@lru_cache(maxsize=1_000_000)
+def is_malicious_account(chain_id: int, address: str) -> str:
+    source_ids = CHAIN_SOURCE_IDS_MAPPING[chain_id]
+    wallet_tag = None
+
+    for source_id in source_ids:
+        labels_url = f"https://api.forta.network/labels/state?entities={address}&sourceIds={source_id}&labels=*xploit*,*hish*,*heist*&limit=1"
+        try:
+            result = requests.get(labels_url).json()
+            if len(result["events"]) == 1:
+                wallet_tag = result["events"][0]["label"]["label"]
+        except Exception as err:
+            logging.error(f"Error obtaining malicious accounts: {err}")
+
+    return wallet_tag
 
 
-def update_known_malicious_accounts(chain_id: int):
-    global KNOWN_MALICIOUS_ACCOUNTS
-    KNOWN_MALICIOUS_ACCOUNTS = dict()
-
-    logging.info("Updating known malicious accounts.")
-
-    # Get all known malicious accounts from LuaBase
-    sql = LUABASE_QUERY[chain_id]
-    url = "https://q.luabase.com/run"
-    payload = {
-        "block": {
-            "details": {
-                "sql": sql,
-                "limit": 50000,
-            }
-        },
-        "api_key": os.environ.get('LUABASE_API_KEY')
-    }
-
-    headers = {"content-type": "application/json"}
-    try: 
-        response = requests.request("POST", url, json=payload, headers=headers)
-        data = response.json()
-
-        KNOWN_MALICIOUS_ACCOUNTS = pd.DataFrame(data["data"]).reset_index(drop=True).set_index("address").to_dict(orient="index")
-        logging.info(f"Obtained {len(KNOWN_MALICIOUS_ACCOUNTS)} malicious accounts.")
-    except Exception as e:
-        logging.error(f"Error obtaining malicious accounts: {e}")
-
-def detect_funding(w3, transaction_event: forta_agent.transaction_event.TransactionEvent) -> list:
-    global KNOWN_MALICIOUS_ACCOUNTS
-
+def detect_funding(
+    w3, transaction_event: forta_agent.transaction_event.TransactionEvent
+) -> list:
     findings = []
 
     from_ = transaction_event.transaction.from_.lower()
-    if transaction_event.transaction.value > 0 and from_ in KNOWN_MALICIOUS_ACCOUNTS.keys():
-        findings.append(MaliciousAccountFundingFinding.funding(transaction_event.transaction.to, from_, KNOWN_MALICIOUS_ACCOUNTS[from_]))
+    malicious_account = is_malicious_account(w3.eth.chain_id, from_)
+    if transaction_event.transaction.value > 0 and malicious_account is not None:
+        findings.append(
+            MaliciousAccountFundingFinding.funding(
+                transaction_event.transaction.to, from_, malicious_account
+            )
+        )
 
     return findings
 
 
 def provide_handle_transaction(w3):
-    def handle_transaction(transaction_event: forta_agent.transaction_event.TransactionEvent) -> list:
+    def handle_transaction(
+        transaction_event: forta_agent.transaction_event.TransactionEvent,
+    ) -> list:
         return detect_funding(w3, transaction_event)
 
     return handle_transaction
@@ -89,16 +76,7 @@ def provide_handle_transaction(w3):
 real_handle_transaction = provide_handle_transaction(web3)
 
 
-def handle_transaction(transaction_event: forta_agent.transaction_event.TransactionEvent):
+def handle_transaction(
+    transaction_event: forta_agent.transaction_event.TransactionEvent,
+):
     return real_handle_transaction(transaction_event)
-
-
-def handle_block(block_event: forta_agent.block_event.BlockEvent) -> list:
-    logging.info(f"Handling block {block_event.block_number}.")
-    global KNOWN_MALICIOUS_ACCOUNTS
-    if len(KNOWN_MALICIOUS_ACCOUNTS) == 0 or block_event.block_number % 240 == 0:
-        logging.info(f"Updating known malicious accounts at block {block_event.block_number}.")
-        update_known_malicious_accounts(web3.eth.chain_id)
-
-    findings = []
-    return findings

--- a/malicious-account-funding-py/src/agent_test.py
+++ b/malicious-account-funding-py/src/agent_test.py
@@ -7,53 +7,44 @@ KNOWN_MALICIOUS_ACCOUNT = "0x000000000532b45f47779fce440748893b257865"
 
 w3 = Web3Mock()
 
+
 class TestKnownMaliciousAccountFunding:
-
     def test_funding(self):
-        agent.initialize()
-        agent.update_known_malicious_accounts(1)
+        tx_event = create_transaction_event(
+            {
+                "transaction": {
+                    "hash": "0",
+                    "from": KNOWN_MALICIOUS_ACCOUNT,
+                    "value": 10,
+                    "to": EOA_ADDRESS,
+                },
+                "block": {"number": 0},
+                "logs": [{}],
+                "receipt": {"logs": []},
+            }
+        )
 
-        tx_event = create_transaction_event({
-            'transaction': {
-                'hash': "0",
-                'from': KNOWN_MALICIOUS_ACCOUNT,
-                'value': 10,
-                'to': EOA_ADDRESS,
-            },
-            'block': {
-                'number': 0
-            },
-            'logs': [
-                {}
-            ],
-            'receipt': {
-                'logs': []}
-        })
-        
         findings = agent.detect_funding(w3, tx_event)
         assert len(findings) == 1, "this should have triggered a finding"
         assert findings[0].alert_id == "MALICIOUS-ACCOUNT-FUNDING"
         assert findings[0].severity == FindingSeverity.High
 
     def test_funding_novalue(self):
-        agent.initialize()
+        tx_event = create_transaction_event(
+            {
+                "transaction": {
+                    "hash": "0",
+                    "from": KNOWN_MALICIOUS_ACCOUNT,
+                    "value": 0,
+                    "to": EOA_ADDRESS,
+                },
+                "block": {"number": 0},
+                "logs": [{}],
+                "receipt": {"logs": []},
+            }
+        )
 
-        tx_event = create_transaction_event({
-            'transaction': {
-                'hash': "0",
-                'from': KNOWN_MALICIOUS_ACCOUNT,
-                'value': 0,
-                'to': EOA_ADDRESS,
-            },
-            'block': {
-                'number': 0
-            },
-            'logs': [
-                {}
-            ],
-            'receipt': {
-                'logs': []}
-        })
-        
         findings = agent.detect_funding(w3, tx_event)
-        assert len(findings) == 0, "this should have not triggered a finding as no funds were transferred"
+        assert (
+            len(findings) == 0
+        ), "this should have not triggered a finding as no funds were transferred"

--- a/malicious-account-funding-py/src/constants.py
+++ b/malicious-account-funding-py/src/constants.py
@@ -1,3 +1,0 @@
-LUABASE_QUERY = {1: "SELECT DISTINCT address, tag FROM ethereum.tags WHERE tag like '%xploit%' or tag like '%hishing%' or label='exploit' or label='heist' or label='phish-hack'",  # ethereum mainnet 
-                137: "SELECT DISTINCT address, tag FROM polygon.tags WHERE tag like '%xploit%' or tag like '%hishing%' or label='exploit' or label='heist' or label='phish-hack'"  # polygon 
-                }

--- a/malicious-account-funding-py/src/findings.py
+++ b/malicious-account-funding-py/src/findings.py
@@ -1,16 +1,34 @@
-from forta_agent import Finding, FindingType, FindingSeverity
+from forta_agent import Finding, FindingType, FindingSeverity, EntityType
 
 
 class MaliciousAccountFundingFinding:
-
     @staticmethod
-    def funding(to_address: str, from_address: str, from_tag: str) -> Finding:
-        finding = Finding({
-            'name': 'Known Malicious Account Funding',
-            'description': f'{to_address} received funds from known malicious account',
-            'alert_id': 'MALICIOUS-ACCOUNT-FUNDING',
-            'type': FindingType.Suspicious,
-            'severity': FindingSeverity.High,
-            'metadata': {'from_address': from_address, 'from_tag': from_tag}
-        })
+    def funding(
+        tx_hash, to_address: str, from_address: str, from_tag: str, anomaly_score: float
+    ) -> Finding:
+        labels = [
+            {
+                "entity": tx_hash,
+                "entity_type": EntityType.Transaction,
+                "label": "malicious-funding",
+                "confidence": 1,
+            }
+        ]
+
+        finding = Finding(
+            {
+                "name": "Known Malicious Account Funding",
+                "description": f"{to_address} received funds from known malicious account",
+                "alert_id": "MALICIOUS-ACCOUNT-FUNDING",
+                "type": FindingType.Suspicious,
+                "severity": FindingSeverity.High,
+                "metadata": {
+                    "from_address": from_address,
+                    "from_tag": from_tag,
+                    "anomaly_score": anomaly_score,
+                },
+                "labels": labels,
+            }
+        )
+
         return finding


### PR DESCRIPTION
## Changes

Removed luabase dependencies and added labels and anomaly scores for the following bots:

- [x] Malicous Account Funding

## Todos
- [ ] @christian-forta once this PR merges, could you deploy the updated malicious account funding bot and enable fantom? (I added fantom support too)