### PR TITLE
Add lower thresholds for money laundering tornado cash

### DIFF
--- a/money-laundering-tornado-cash-py/README.md
+++ b/money-laundering-tornado-cash-py/README.md
@@ -17,10 +17,26 @@ This detection bot detects when numerous large transfers are made to Tornado Cas
 Describe each of the type of alerts fired by this agent
 
 - POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH
-  - Fired when possible money laundering is identified
+
+  - Fired when possible money laundering is identified over the highest threshold
   - Metadata will contain amount if funds transferred in the block range specifified in the configuration
   - Findings severity will be High
-  - Low confidence labels (0.5) for attacker address 
+  - Low confidence labels (0.5) for attacker address
+  - Metadata exposes the anomaly_score for the alert (calculated by dividing TC laundering tx by all transfer out tx)
+
+- POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-MEDIUM
+
+  - Fired when possible money laundering is identified over the medium threshold
+  - Metadata will contain amount if funds transferred in the block range specifified in the configuration
+  - Findings severity will be Medium
+  - Low confidence labels (0.5) for attacker address
+  - Metadata exposes the anomaly_score for the alert (calculated by dividing TC laundering tx by all transfer out tx)
+
+- POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-LOW
+  - Fired when possible money laundering is identified over the low threshold
+  - Metadata will contain amount if funds transferred in the block range specifified in the configuration
+  - Findings severity will be Low
+  - Low confidence labels (0.5) for attacker address
   - Metadata exposes the anomaly_score for the alert (calculated by dividing TC laundering tx by all transfer out tx)
 
 ## Test Data

--- a/money-laundering-tornado-cash-py/src/agent.py
+++ b/money-laundering-tornado-cash-py/src/agent.py
@@ -6,13 +6,9 @@ from forta_agent import get_json_rpc_url
 from web3 import Web3
 from os import environ
 
-from src.constants import (BLOCK_RANGE, TORNADO_CASH_ACCOUNTS_QUEUE_SIZE,
-                           TORNADO_CASH_ADDRESSES, TORNADO_CASH_DEPOSIT_SIZE,
-                           TORNADO_CASH_DEPOSIT_SIZE_MATIC,
-                           TORNADO_CASH_DEPOSIT_TOPIC,
-                           TORNADO_CASH_TRANSFER_COUNT_THRESHOLD_BSC,
-                           TORNADO_CASH_TRANSFER_COUNT_THRESHOLD_ETH,
-                           TORNADO_CASH_TRANSFER_COUNT_THRESHOLD_MATIC)
+from src.constants import (TORNADO_CASH_ACCOUNTS_QUEUE_SIZE,
+                           TORNADO_CASH_ADDRESSES, TORNADO_CASH_TRANSFER_AMOUNT_THRESHOLDS,
+                           TORNADO_CASH_DEPOSIT_TOPIC,)
 from src.findings import MoneyLaunderingTornadoCashFindings
 from src.storage import get_secrets
 
@@ -21,7 +17,6 @@ SECRETS_JSON = get_secrets()
 web3 = Web3(Web3.HTTPProvider(get_json_rpc_url()))
 
 # dict of accounts to dicts of blocks to counts; e.g. # account 1, block 101, 1
-ACCOUNT_TO_TORNADO_CASH_BLOCKS = {}
 ACCOUNT_QUEUE = []
 
 
@@ -41,8 +36,6 @@ def initialize():
     this function initializes the state variables that are tracked across tx and blocks
     it is called from test to reset state between tests
     """
-    global ACCOUNT_TO_TORNADO_CASH_BLOCKS
-    ACCOUNT_TO_TORNADO_CASH_BLOCKS = {}
 
     global ACCOUNT_QUEUE
     ACCOUNT_QUEUE = []
@@ -54,7 +47,6 @@ def initialize():
 
 
 def detect_money_laundering(w3, transaction_event: forta_agent.transaction_event.TransactionEvent) -> list:
-    global ACCOUNT_TO_TORNADO_CASH_BLOCKS
     global ACCOUNT_QUEUE
 
     logging.info(
@@ -74,30 +66,15 @@ def detect_money_laundering(w3, transaction_event: forta_agent.transaction_event
             logging.info(
                 f"Identified account {account} on chain {w3.eth.chain_id}")
 
-            block_to_tx_count = {}
-            if account not in ACCOUNT_TO_TORNADO_CASH_BLOCKS:
-                ACCOUNT_TO_TORNADO_CASH_BLOCKS[account] = block_to_tx_count
             else:
                 block_to_tx_count = ACCOUNT_TO_TORNADO_CASH_BLOCKS[account]
 
-            if transaction_event.block_number not in block_to_tx_count.keys():
-                block_to_tx_count[transaction_event.block_number] = 1
-            else:
-                block_to_tx_count[transaction_event.block_number] += 1
 
             #  maintain a size
             if len(ACCOUNT_QUEUE) > TORNADO_CASH_ACCOUNTS_QUEUE_SIZE:
                 acc = ACCOUNT_QUEUE.pop(0)
-                ACCOUNT_TO_TORNADO_CASH_BLOCKS.pop(acc, None)
-
-            while max(block_to_tx_count.keys()) - min(block_to_tx_count.keys()) > BLOCK_RANGE[w3.eth.chain_id]:
-                #  remove the oldest blocks
-                oldest_block = min(block_to_tx_count,
-                                   key=block_to_tx_count.get)
-                block_to_tx_count.pop(oldest_block, None)
 
     if account in ACCOUNT_QUEUE:
-        total_txs = sum(ACCOUNT_TO_TORNADO_CASH_BLOCKS[account].values())
         logging.info(f"Account {account} total txs {total_txs}")
 
         tx_threshold = TORNADO_CASH_TRANSFER_COUNT_THRESHOLD_ETH

--- a/money-laundering-tornado-cash-py/src/agent_test.py
+++ b/money-laundering-tornado-cash-py/src/agent_test.py
@@ -8,23 +8,27 @@ from web3_mock import EOA_ADDRESS, Web3Mock
 w3 = Web3Mock()
 
 
+TORNADO_CASH_ADDRESSES = {"0xa160cdab225685da1d56aa342ad8841c3b53f291": 100, "0x910cbd523d972eb0a6f4cae4618ad62622b39dbf": 10, "0x47ce0c6ed5b0ce3d3a51fdb1c52dc66a7c3c2936": 1, "0x1e34a77868e19a6647b1f2f47b51ed72dede95dd": 100,
+                          "0x330bdfade01ee9bf63c209ee33102dd334618e0a": 10, "0xd47438c816c9e7f2e2888e060936a499af9582b3": 1, "0xa5c2254e4253490c54cef0a4347fddb8f75a4998": 100000, "0xaf4c0b70b2ea9fb7487c7cbb37ada259579fe040": 10000, "0xdf231d99ff8b6c6cbf4e9b9a945cbacef9339178": 1000}
+
+
 class TestSuspiciousContractAgent:
     @patch("src.findings.calculate_alert_rate", return_value=0.33)
-    def test_detect_money_laundering_at_threshold_within_blockrange(self, mocker):
+    def test_detect_money_laundering_at_low_threshold_within_blockrange(self, mocker):
         agent.initialize()
 
         tx_event = create_transaction_event({
             'transaction': {
                 'hash': "0",
                 'from': EOA_ADDRESS,
-                'value': 100000000000000000000,
+                'value': 1000000000000000000,
                 'to': TORNADO_CASH_ADDRESSES,
             },
             'block': {
                 'number': 0
             },
             'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[1],
+                {'address': "0x47ce0c6ed5b0ce3d3a51fdb1c52dc66a7c3c2936",
                  'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                  }
             ],
@@ -38,14 +42,14 @@ class TestSuspiciousContractAgent:
             'transaction': {
                 'hash': "0",
                 'from': EOA_ADDRESS,
-                'value': 100000000000000000000,
+                'value': 10000000000000000000,
                 'to': TORNADO_CASH_ADDRESSES,
             },
             'block': {
                 'number': 1
             },
             'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[1],
+                {'address': "0x910cbd523d972eb0a6f4cae4618ad62622b39dbf",
                  'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                  }
             ],
@@ -66,7 +70,7 @@ class TestSuspiciousContractAgent:
                 'number': 2
             },
             'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[1],
+                {'address': "0xa160cdab225685da1d56aa342ad8841c3b53f291",
                  'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                  }
             ],
@@ -76,10 +80,10 @@ class TestSuspiciousContractAgent:
         findings = agent.detect_money_laundering(w3, tx_event)
         assert len(findings) == 1, "this should have triggered a finding"
         finding = next((x for x in findings if x.alert_id ==
-                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH'), None)
-        assert finding.severity == FindingSeverity.High
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-LOW'), None)
+        assert finding.severity == FindingSeverity.Low
         assert finding.metadata == {
-            "anomaly_score": 0.33, "total_funds_transferred": "300"}
+            "anomaly_score": 0.33, "total_funds_transferred": "111"}
 
         assert finding.metadata["anomaly_score"] == 0.33, "should have anomaly score of 1/3"
         assert finding.labels[0].toDict(
@@ -91,7 +95,7 @@ class TestSuspiciousContractAgent:
         assert finding.labels[0].toDict(
         )["confidence"] == 0.5, "should have 0.3 as label confidence"
 
-    def test_detect_money_laundering_at_threshold_outside_blockrange(self):
+    def test_detect_money_laundering_at_medium_threshold_within_blockrange(self):
         agent.initialize()
 
         tx_event = create_transaction_event({
@@ -105,7 +109,7 @@ class TestSuspiciousContractAgent:
                 'number': 0
             },
             'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[1],
+                {'address': "0xa160cdab225685da1d56aa342ad8841c3b53f291",
                  'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                  }
             ],
@@ -113,7 +117,11 @@ class TestSuspiciousContractAgent:
                 'logs': []}
         })
         findings = agent.detect_money_laundering(w3, tx_event)
-        assert len(findings) == 0, "this should not have triggered a finding"
+        assert len(
+            findings) == 1, "this should have triggered a low severity finding"
+        finding = next((x for x in findings if x.alert_id ==
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-LOW'), None)
+        assert finding.severity == FindingSeverity.Low
 
         tx_event = create_transaction_event({
             'transaction': {
@@ -126,7 +134,7 @@ class TestSuspiciousContractAgent:
                 'number': 1
             },
             'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[1],
+                {'address': "0x910cbd523d972eb0a6f4cae4618ad62622b39dbf",
                  'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                  }
             ],
@@ -134,7 +142,11 @@ class TestSuspiciousContractAgent:
                 'logs': []}
         })
         findings = agent.detect_money_laundering(w3, tx_event)
-        assert len(findings) == 0, "this should not have triggered a finding"
+        assert len(
+            findings) == 1, "this should have triggered a low severity finding"
+        finding = next((x for x in findings if x.alert_id ==
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-LOW'), None)
+        assert finding.severity == FindingSeverity.Low
 
         tx_event = create_transaction_event({
             'transaction': {
@@ -147,7 +159,7 @@ class TestSuspiciousContractAgent:
                 'number': 241
             },
             'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[1],
+                {'address': "0xa160cdab225685da1d56aa342ad8841c3b53f291",
                  'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                  }
             ],
@@ -156,7 +168,142 @@ class TestSuspiciousContractAgent:
         })
         findings = agent.detect_money_laundering(w3, tx_event)
         assert len(
-            findings) == 0, "this should not have triggered a finding as third transaction happened outside block range"
+            findings) == 1, "this should have triggered a medium severity finding"
+        finding = next((x for x in findings if x.alert_id ==
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-MEDIUM'), None)
+        assert finding.severity == FindingSeverity.Medium
+        assert finding.metadata == {
+            "anomaly_score": 1, "total_funds_transferred": "210"}
+
+    def test_detect_money_laundering_at_high_threshold_within_blockrange(self):
+        agent.initialize()
+
+        tx_event = create_transaction_event({
+            'transaction': {
+                'hash': "0",
+                'from': EOA_ADDRESS,
+                'value': 100000000000000000000,
+                'to': TORNADO_CASH_ADDRESSES,
+            },
+            'block': {
+                'number': 0
+            },
+            'logs': [
+                {'address': "0xa160cdab225685da1d56aa342ad8841c3b53f291",
+                 'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
+                 }
+            ],
+            'receipt': {
+                'logs': []}
+        })
+        findings = agent.detect_money_laundering(w3, tx_event)
+        assert len(
+            findings) == 1, "this should have triggered a low severity finding"
+        finding = next((x for x in findings if x.alert_id ==
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-LOW'), None)
+        assert finding.severity == FindingSeverity.Low
+
+        tx_event = create_transaction_event({
+            'transaction': {
+                'hash': "0",
+                'from': EOA_ADDRESS,
+                'value': 100000000000000000000,
+                'to': TORNADO_CASH_ADDRESSES,
+            },
+            'block': {
+                'number': 1
+            },
+            'logs': [
+                {'address': "0xa160cdab225685da1d56aa342ad8841c3b53f291",
+                 'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
+                 }
+            ],
+            'receipt': {
+                'logs': []}
+        })
+        findings = agent.detect_money_laundering(w3, tx_event)
+        assert len(
+            findings) == 1, "this should have triggered a medium severity finding"
+        finding = next((x for x in findings if x.alert_id ==
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-MEDIUM'), None)
+        assert finding.severity == FindingSeverity.Medium
+
+        tx_event = create_transaction_event({
+            'transaction': {
+                'hash': "0",
+                'from': EOA_ADDRESS,
+                'value': 100000000000000000000,
+                'to': TORNADO_CASH_ADDRESSES,
+            },
+            'block': {
+                'number': 2
+            },
+            'logs': [
+                {'address': "0xa160cdab225685da1d56aa342ad8841c3b53f291",
+                 'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
+                 }
+            ],
+            'receipt': {
+                'logs': []}
+        })
+        findings = agent.detect_money_laundering(w3, tx_event)
+        assert len(
+            findings) == 1, "this should have triggered a medium severity finding"
+        finding = next((x for x in findings if x.alert_id ==
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-MEDIUM'), None)
+        assert finding.severity == FindingSeverity.Medium
+
+        tx_event = create_transaction_event({
+            'transaction': {
+                'hash': "0",
+                'from': EOA_ADDRESS,
+                'value': 100000000000000000000,
+                'to': TORNADO_CASH_ADDRESSES,
+            },
+            'block': {
+                'number': 3
+            },
+            'logs': [
+                {'address': "0xa160cdab225685da1d56aa342ad8841c3b53f291",
+                 'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
+                 }
+            ],
+            'receipt': {
+                'logs': []}
+        })
+        findings = agent.detect_money_laundering(w3, tx_event)
+        assert len(
+            findings) == 1, "this should have triggered a medium severity finding"
+        finding = next((x for x in findings if x.alert_id ==
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-MEDIUM'), None)
+        assert finding.severity == FindingSeverity.Medium
+
+        tx_event = create_transaction_event({
+            'transaction': {
+                'hash': "0",
+                'from': EOA_ADDRESS,
+                'value': 100000000000000000000,
+                'to': TORNADO_CASH_ADDRESSES,
+            },
+            'block': {
+                'number': 4
+            },
+            'logs': [
+                {'address': "0xa160cdab225685da1d56aa342ad8841c3b53f291",
+                 'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
+                 }
+            ],
+            'receipt': {
+                'logs': []}
+        })
+        findings = agent.detect_money_laundering(w3, tx_event)
+        assert len(
+            findings) == 1, "this should have triggered a high severity finding"
+        finding = next((x for x in findings if x.alert_id ==
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH'), None)
+        assert finding.severity == FindingSeverity.High
+        assert finding.metadata == {
+            "anomaly_score": 1, "total_funds_transferred": "500"}
 
     def test_detect_money_laundering_below_threshold(self):
         agent.initialize()
@@ -172,7 +319,7 @@ class TestSuspiciousContractAgent:
                 'number': 2
             },
             'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[1],
+                {'address': "0x47ce0c6ed5b0ce3d3a51fdb1c52dc66a7c3c2936",
                  'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                  }
             ],
@@ -181,74 +328,6 @@ class TestSuspiciousContractAgent:
         })
         findings = agent.detect_money_laundering(w3, tx_event)
         assert len(findings) == 0, "this should not have triggered a finding"
-
-    def test_detect_money_laundering_incorrect_tornado_cash_contract_mainnet(self):
-        agent.initialize()
-
-        w3.chain_id = 1
-
-        tx_event = create_transaction_event({
-            'transaction': {
-                'hash': "0",
-                'from': EOA_ADDRESS,
-                'value': 100000000000000000000,
-                'to': TORNADO_CASH_ADDRESSES,
-            },
-            'block': {
-                'number': 0
-            },
-            'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[137],
-                 'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
-                 }
-            ],
-            'receipt': {
-                'logs': []}
-        })
-        findings = agent.detect_money_laundering(w3, tx_event)
-        assert len(findings) == 0, "this should have triggered a finding"
-
-        tx_event = create_transaction_event({
-            'transaction': {
-                'hash': "0",
-                'from': EOA_ADDRESS,
-                'value': 100000000000000000000,
-                'to': TORNADO_CASH_ADDRESSES,
-            },
-            'block': {
-                'number': 1
-            },
-            'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[137],
-                 'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
-                 }
-            ],
-            'receipt': {
-                'logs': []}
-        })
-        findings = agent.detect_money_laundering(w3, tx_event)
-        assert len(findings) == 0, "this should have triggered a finding"
-
-        tx_event = create_transaction_event({
-            'transaction': {
-                'hash': "0",
-                'from': EOA_ADDRESS,
-                'value': 100000000000000000000,
-                'to': TORNADO_CASH_ADDRESSES,
-            },
-            'block': {
-                'number': 2
-            },
-            'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[137],
-                 'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
-                 }
-            ],
-            'receipt': {
-                'logs': []}
-        })
-        findings = agent.detect_money_laundering(w3, tx_event)
-        assert len(findings) == 0, "this should have triggered a finding"
 
     def test_detect_money_laundering_below_threshold_polygon(self):
         agent.initialize()
@@ -266,7 +345,7 @@ class TestSuspiciousContractAgent:
                 'number': 0
             },
             'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[137],
+                {'address': "0xaf4c0b70b2ea9fb7487c7cbb37ada259579fe040",
                  'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                  }
             ],
@@ -274,7 +353,7 @@ class TestSuspiciousContractAgent:
                 'logs': []}
         })
         findings = agent.detect_money_laundering(w3, tx_event)
-        assert len(findings) == 0, "this should have triggered a finding"
+        assert len(findings) == 0, "this should not have triggered a finding"
 
         tx_event = create_transaction_event({
             'transaction': {
@@ -287,7 +366,7 @@ class TestSuspiciousContractAgent:
                 'number': 1
             },
             'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[137],
+                {'address': "0xa5c2254e4253490c54cef0a4347fddb8f75a4998",
                  'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                  }
             ],
@@ -295,35 +374,15 @@ class TestSuspiciousContractAgent:
                 'logs': []}
         })
         findings = agent.detect_money_laundering(w3, tx_event)
-        assert len(findings) == 0, "this should have triggered a finding"
+        assert len(
+            findings) == 1, "this should have triggered a low severity finding"
+        finding = next((x for x in findings if x.alert_id ==
+                       'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-LOW'), None)
+        assert finding.severity == FindingSeverity.Low
+        assert finding.metadata == {
+            "anomaly_score": 1, "total_funds_transferred": "110000"}
 
-        tx_event = create_transaction_event({
-            'transaction': {
-                'hash': "0",
-                'from': EOA_ADDRESS,
-                'value': 100000000000000000000,
-                'to': TORNADO_CASH_ADDRESSES,
-            },
-            'block': {
-                'number': 2
-            },
-            'logs': [
-                {'address': TORNADO_CASH_ADDRESSES[137],
-                 'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
-                 }
-            ],
-            'receipt': {
-                'logs': []}
-        })
-        findings = agent.detect_money_laundering(w3, tx_event)
-        assert len(findings) == 0, "this should have triggered a finding"
-
-    def test_detect_money_laundering_at_threshold_polygon(self):
-        agent.initialize()
-
-        w3.eth.chain_id = 137
-
-        for i in range(100):
+        for i in range(15):
             tx_event = create_transaction_event({
                 'transaction': {
                     'hash': "0",
@@ -335,7 +394,7 @@ class TestSuspiciousContractAgent:
                     'number': i
                 },
                 'logs': [
-                    {'address': TORNADO_CASH_ADDRESSES[137],
+                    {'address': "0xa5c2254e4253490c54cef0a4347fddb8f75a4998",
                      'topics': ['0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'],
                      }
                 ],
@@ -343,5 +402,19 @@ class TestSuspiciousContractAgent:
                     'logs': []}
             })
             findings = agent.detect_money_laundering(w3, tx_event)
-
-        assert len(findings) == 1, "this should have triggered a finding"
+            if i == 5:
+                assert len(
+                    findings) == 1, "this should have triggered a finding"
+                finding = next((x for x in findings if x.alert_id ==
+                                'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-MEDIUM'), None)
+                assert finding.severity == FindingSeverity.Medium
+                assert finding.metadata == {
+                    "anomaly_score": 1, "total_funds_transferred": "710000"}
+            elif i == 14:
+                assert len(
+                    findings) == 1, "this should have triggered a finding"
+                finding = next((x for x in findings if x.alert_id ==
+                                'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH'), None)
+                assert finding.severity == FindingSeverity.High
+                assert finding.metadata == {
+                    "anomaly_score": 1, "total_funds_transferred": "1610000"}

--- a/money-laundering-tornado-cash-py/src/constants.py
+++ b/money-laundering-tornado-cash-py/src/constants.py
@@ -10,12 +10,28 @@ TORNADO_CASH_TRANSFER_AMOUNT_THRESHOLDS = {1: {"high": 500, "medium": 200, "low"
 TORNADO_CASH_ACCOUNTS_QUEUE_SIZE = 10000
 
 # Obtained from https://docs.tornado.cash/general/tornado-cash-smart-contracts#tornado-cash-classic-pools-contracts
-TORNADO_CASH_ADDRESSES = {1: "0xA160cdAB225685dA1d56aa342Ad8841c3b53f291",  # Ethereum Mainnet - 100 ETH
-                          56: "0x1E34A77868E19A6647b1f2F47B51ed72dEDE95DD",  # BSC - 100 BNB
-                          42161: "0x1E34A77868E19A6647b1f2F47B51ed72dEDE95DD",  # ARBITRUM - 100 ETH
-                          10: "0x1E34A77868E19A6647b1f2F47B51ed72dEDE95DD",  # OPTIMISM - 100 ETH
-                          137: "0xa5C2254e4253490C54cef0a4347fddb8f75A4998"  # POLYGON - 100000 MATIC
-                          }
+# Ethereum 100 eth: 0xa160cdab225685da1d56aa342ad8841c3b53f291
+# Ethereum 10 eth: 0x910cbd523d972eb0a6f4cae4618ad62622b39dbf
+# Ethereum 1 eth: 0x47ce0c6ed5b0ce3d3a51fdb1c52dc66a7c3c2936
+
+# BSC 100 bnb: 0x1e34a77868e19a6647b1f2f47b51ed72dede95dd
+# BSC 10 bnb: 0x330bdfade01ee9bf63c209ee33102dd334618e0a
+# BSC 1 bnb: 0xd47438c816c9e7f2e2888e060936a499af9582b3
+
+# Arbitrum 100 eth: 0x1e34a77868e19a6647b1f2f47b51ed72dede95dd
+# Arbitrum 10 eth: 0x330bdfade01ee9bf63c209ee33102dd334618e0a
+# Arbitrum 1 eth: 0xd47438c816c9e7f2e2888e060936a499af9582b3
+
+# Optimism 100 eth: 0x1e34a77868e19a6647b1f2f47b51ed72dede95dd
+# Optimism 10 eth: 0x330bdfade01ee9bf63c209ee33102dd334618e0a
+# Optimism 1 eth: 0xd47438c816c9e7f2e2888e060936a499af9582b3
+
+# Polygon 100000 matic: 0xa5c2254e4253490c54cef0a4347fddb8f75a4998
+# Polygon 10000 matic: 0xaf4c0b70b2ea9fb7487c7cbb37ada259579fe040
+# Polygon 1000 matic: 0xdf231d99ff8b6c6cbf4e9b9a945cbacef9339178
+
+TORNADO_CASH_ADDRESSES = {"0xa160cdab225685da1d56aa342ad8841c3b53f291": 100, "0x910cbd523d972eb0a6f4cae4618ad62622b39dbf": 10, "0x47ce0c6ed5b0ce3d3a51fdb1c52dc66a7c3c2936": 1, "0x1e34a77868e19a6647b1f2f47b51ed72dede95dd": 100,
+                          "0x330bdfade01ee9bf63c209ee33102dd334618e0a": 10, "0xd47438c816c9e7f2e2888e060936a499af9582b3": 1, "0xa5c2254e4253490c54cef0a4347fddb8f75a4998": 100000, "0xaf4c0b70b2ea9fb7487c7cbb37ada259579fe040": 10000, "0xdf231d99ff8b6c6cbf4e9b9a945cbacef9339178": 1000}
 
 
 TORNADO_CASH_DEPOSIT_TOPIC = '0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'

--- a/money-laundering-tornado-cash-py/src/constants.py
+++ b/money-laundering-tornado-cash-py/src/constants.py
@@ -1,11 +1,13 @@
-BLOCK_RANGE = {1: 240, 56: 1200, 42161: 3600, 10: 300, 137: 1300}  # what block range should be utilized to assess the TORNADO_CASH_TRANSFER_COUNT_THRESHOLD; about an hour
+# High thresholds are nearly 1M USD, medium thresholds are nearly 400K USD, and low thresholds are nearly 40K USD
+TORNADO_CASH_TRANSFER_AMOUNT_THRESHOLDS = {1: {"high": 500, "medium": 200, "low": 20},
+                                           56: {"high": 4000, "medium": 1600, "low": 160},
+                                           42161: {"high": 500, "medium": 200, "low": 20},
+                                           10: {"high": 500, "medium": 200, "low": 20},
+                                           137: {"high": 1500000, "medium": 600000, "low": 60000}}
 
 
-# how many tornado cash transfers should be in a block range to be considered suspicious; currently configured to be about 1M USD
-TORNADO_CASH_TRANSFER_COUNT_THRESHOLD_ETH = 3  # 1M USD / (100 ETH * 3000 USD)
-TORNADO_CASH_TRANSFER_COUNT_THRESHOLD_MATIC = 75  # 1M USD / (10000 MATIC * 1.35 USD)
-TORNADO_CASH_TRANSFER_COUNT_THRESHOLD_BSC = 25  # 1M USD / (100 BSC * 400 USD)
-TORNADO_CASH_ACCOUNTS_QUEUE_SIZE = 10000  # how many accounts should be tracked by the bot in memory before dequeuing items
+# how many accounts should be tracked by the bot in memory before dequeuing items
+TORNADO_CASH_ACCOUNTS_QUEUE_SIZE = 10000
 
 # Obtained from https://docs.tornado.cash/general/tornado-cash-smart-contracts#tornado-cash-classic-pools-contracts
 TORNADO_CASH_ADDRESSES = {1: "0xA160cdAB225685dA1d56aa342Ad8841c3b53f291",  # Ethereum Mainnet - 100 ETH
@@ -14,8 +16,6 @@ TORNADO_CASH_ADDRESSES = {1: "0xA160cdAB225685dA1d56aa342Ad8841c3b53f291",  # Et
                           10: "0x1E34A77868E19A6647b1f2F47B51ed72dEDE95DD",  # OPTIMISM - 100 ETH
                           137: "0xa5C2254e4253490C54cef0a4347fddb8f75A4998"  # POLYGON - 100000 MATIC
                           }
-TORNADO_CASH_DEPOSIT_SIZE = 100
-TORNADO_CASH_DEPOSIT_SIZE_MATIC = 100000
 
 
 TORNADO_CASH_DEPOSIT_TOPIC = '0xa945e51eec50ab98c161376f0db4cf2aeba3ec92755fe2fcd388bdbbb80ff196'

--- a/money-laundering-tornado-cash-py/src/findings.py
+++ b/money-laundering-tornado-cash-py/src/findings.py
@@ -30,3 +30,53 @@ class MoneyLaunderingTornadoCashFindings:
             },
             "labels": labels
         })
+
+    @staticmethod
+    def possible_money_laundering_tornado_cash_medium(from_address: str, funds_transferred: int, chain_id: int) -> Finding:
+        labels = [{"entity": from_address,
+                   "entity_type": EntityType.Address,
+                   "label": "attacker",
+                   "confidence": 0.5}]
+
+        return Finding({
+            'name': 'Possible Money Laundering With Tornado Cash',
+            'description': f'{from_address} potentially engaged in money laundering',
+            'alert_id': 'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-MEDIUM',
+            'type': FindingType.Suspicious,
+            'severity': FindingSeverity.Medium,
+            'metadata': {
+                "anomaly_score": calculate_alert_rate(
+                        chain_id,
+                        BOT_ID,
+                        'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-MEDIUM',
+                        ScanCountType.TRANSFER_COUNT,
+                ),
+                "total_funds_transferred": str(funds_transferred)
+            },
+            "labels": labels
+        })
+
+    @staticmethod
+    def possible_money_laundering_tornado_cash_low(from_address: str, funds_transferred: int, chain_id: int) -> Finding:
+        labels = [{"entity": from_address,
+                   "entity_type": EntityType.Address,
+                   "label": "attacker",
+                   "confidence": 0.5}]
+
+        return Finding({
+            'name': 'Possible Money Laundering With Tornado Cash',
+            'description': f'{from_address} potentially engaged in money laundering',
+            'alert_id': 'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-LOW',
+            'type': FindingType.Suspicious,
+            'severity': FindingSeverity.Low,
+            'metadata': {
+                "anomaly_score": calculate_alert_rate(
+                        chain_id,
+                        BOT_ID,
+                        'POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-LOW',
+                        ScanCountType.TRANSFER_COUNT,
+                ),
+                "total_funds_transferred": str(funds_transferred)
+            },
+            "labels": labels
+        })


### PR DESCRIPTION
Added 2 new alert types. Now there are 3 types of alerts:

1. POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH (High Severity)
- Approximately over 1M USD
3. POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-MEDIUM (Medium Severity)
- Approximately over 400K USD
5. POSSIBLE-MONEY-LAUNDERING-TORNADO-CASH-LOW (Low Severity)
- Approximately over 40K USD


Added New Tornado cash contracts including: 
100 ETH, 10 ETH, 1 ETH
100 BNB, 10 BNB, 1 BNB
100000 MATIC, 10000 MATIC, 1000 MATIC

Accounts are added into queue with this format:
```
[
  {'account': '0xCf945b97dCac69c09A82cD6c2F2a29AFecC21A23', 'value': 510}, 
  {'account': '0xa8ca3D2521e35be3E50e658a3c0080a5Eaa60dE3', 'value': 1}
]
```
`value` is their total transfers to TC

