### PR TITLE
Unverified contract performance fix

### DIFF
--- a/unverified-contract-py/README.md
+++ b/unverified-contract-py/README.md
@@ -24,3 +24,4 @@ Describe each of the type of alerts fired by this agent
 The agent behaviour can be verified with the following transactions:
 
 - 0x531e42376038809d98fd488edddb33126431bda870bd3f43984025486a3f4f68 (Fei Rari attacker contract)
+- 0x16718a6df144de749035e4763946ad56d3dfaeb5d151a82f913698fa4ae28c3d (Conic Finance Exploiter contract)

--- a/unverified-contract-py/package.json
+++ b/unverified-contract-py/package.json
@@ -4,10 +4,38 @@
   "description": "Forta agent raising alerts on unverified contract creations.",
   "repository": "https://github.com/forta-network/starter-kits/tree/main/unverified-contract-py",
   "chainIds": [
-    1, 56, 137, 42161, 10, 250, 43114
+    1,
+    56,
+    137,
+    42161,
+    10,
+    250,
+    43114
   ],
+  "chainSettings": {
+    "1": {
+      "shards": 2,
+      "target": 3
+    },
+    "10": {
+      "shards": 2,
+      "target": 2
+    },
+    "250": {
+      "shards": 2,
+      "target": 3
+    },
+    "42161": {
+      "shards": 2,
+      "target": 2
+    },
+    "43114": {
+      "shards": 2,
+      "target": 3
+    }
+  },
   "scripts": {
-    "postinstall": "python3 -m pip install -r requirements_dev.txt",
+    "postinstall": "python -m pip install -r requirements_dev.txt",
     "start": "npm run start:dev",
     "start:dev": "nodemon --watch src --watch forta.config.json -e py --exec \"forta-agent run\"",
     "start:prod": "forta-agent run --prod",

--- a/unverified-contract-py/src/agent.py
+++ b/unverified-contract-py/src/agent.py
@@ -371,8 +371,8 @@ def provide_handle_transaction(w3, blockexplorer):
 
         cache_contract_creation(w3, transaction_event)
         # uncomment for local testing; otherwise the process will exit
-        while thread.is_alive():
-            pass
+        # while thread.is_alive():
+        #     pass
 
         findings = FINDINGS_CACHE
         FINDINGS_CACHE = []

--- a/unverified-contract-py/src/agent.py
+++ b/unverified-contract-py/src/agent.py
@@ -3,6 +3,8 @@ import sys
 import threading
 from datetime import datetime, timedelta
 from os import environ
+import concurrent.futures
+from functools import lru_cache
 
 import forta_agent
 import rlp
@@ -13,7 +15,7 @@ from web3 import Web3
 import time
 
 from src.blockexplorer import BlockExplorer
-from src.constants import CONTRACT_SLOT_ANALYSIS_DEPTH, WAIT_TIME
+from src.constants import CONTRACT_SLOT_ANALYSIS_DEPTH, WAIT_TIME, CONCURRENT_SIZE
 from src.findings import UnverifiedCodeContractFindings
 from src.storage import get_secrets
 
@@ -33,8 +35,7 @@ root.setLevel(logging.INFO)
 
 handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.INFO)
-formatter = logging.Formatter(
-    '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 handler.setFormatter(formatter)
 root.addHandler(handler)
 
@@ -59,7 +60,7 @@ def initialize():
     global CHAIN_ID
     CHAIN_ID = web3.eth.chain_id
 
-    environ["ZETTABLOCK_API_KEY"] = SECRETS_JSON['apiKeys']['ZETTABLOCK']
+    environ["ZETTABLOCK_API_KEY"] = SECRETS_JSON["apiKeys"]["ZETTABLOCK"]
 
 
 def calc_contract_address(w3, address, nonce) -> str:
@@ -72,6 +73,7 @@ def calc_contract_address(w3, address, nonce) -> str:
     return Web3.toChecksumAddress(Web3.keccak(rlp.encode([address_bytes, nonce]))[-20:])
 
 
+@lru_cache(maxsize=12800)
 def is_contract(w3, address) -> bool:
     """
     this function determines whether address is a contract
@@ -79,8 +81,12 @@ def is_contract(w3, address) -> bool:
     """
     if address is None:
         return True
-    code = w3.eth.get_code(Web3.toChecksumAddress(address))
-    return code != HexBytes('0x')
+    try:
+        code = w3.eth.get_code(Web3.toChecksumAddress(address))
+        return code != HexBytes("0x")
+    except Exception as e:
+        logging.warn(f"Web3 error for is_contract method", {address: address, e: e})
+        return False
 
 
 def get_storage_addresses(w3, address) -> set:
@@ -88,18 +94,41 @@ def get_storage_addresses(w3, address) -> set:
     this function returns the addresses that are references in the storage of a contract (first CONTRACT_SLOT_ANALYSIS_DEPTH slots)
     :return: address_list: list (only returning contract addresses)
     """
+    start_time = time.time()
+
     if address is None:
         return set()
 
     address_set = set()
-    for i in range(CONTRACT_SLOT_ANALYSIS_DEPTH):
-        mem = w3.eth.get_storage_at(Web3.toChecksumAddress(address), i)
-        if mem != HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000'):
-            # looking at both areas of the storage slot as - depending on packing - the address could be at the beginning or the end.
-            if is_contract(w3, mem[0:20]):
-                address_set.add(Web3.toChecksumAddress(mem[0:20].hex()))
-            if is_contract(w3, mem[12:]):
-                address_set.add(Web3.toChecksumAddress(mem[12:].hex()))
+
+    def get_storage_at_slot(size):
+        for i in size:
+            try:
+                mem = w3.eth.get_storage_at(Web3.toChecksumAddress(address), i)
+                if mem != HexBytes(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                ):
+                    # looking at both areas of the storage slot as - depending on packing - the address could be at the beginning or the end.
+                    if is_contract(w3, mem[0:20]):
+                        address_set.add(Web3.toChecksumAddress(mem[0:20].hex()))
+                    if is_contract(w3, mem[12:]):
+                        address_set.add(Web3.toChecksumAddress(mem[12:].hex()))
+            except Exception as e:
+                logging.warning(
+                    f"Web3 Error at get_storage_at method", {address: address, e: e}
+                )
+
+    concurrent_sizes = [
+        range(i, min(i + CONCURRENT_SIZE, CONTRACT_SLOT_ANALYSIS_DEPTH))
+        for i in range(0, CONTRACT_SLOT_ANALYSIS_DEPTH, CONCURRENT_SIZE)
+    ]
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        executor.map(get_storage_at_slot, concurrent_sizes)
+
+    end_time = time.time()
+
+    logging.info(f"get_storage_addresses took {end_time - start_time} seconds")
 
     return address_set
 
@@ -109,28 +138,39 @@ def get_opcode_addresses(w3, address) -> set:
     this function returns the addresses that are references in the opcodes of a contract
     :return: address_list: list (only returning contract addresses)
     """
+    start_time = time.time()
+
     if address is None:
         return set()
 
     code = w3.eth.get_code(Web3.toChecksumAddress(address))
     opcode = disassemble_hex(code.hex())
+
     address_set = set()
     for op in opcode.splitlines():
-        for param in op.split(' '):
-            if param.startswith('0x') and len(param) == 42:
+        for param in op.split(" "):
+            if param.startswith("0x") and len(param) == 42:
                 if is_contract(w3, param):
                     address_set.add(Web3.toChecksumAddress(param))
+
+    end_time = time.time()
+
+    logging.info(f"get_opcode_addresses took {end_time - start_time} seconds")
 
     return address_set
 
 
-def cache_contract_creation(w3, blockexplorer, transaction_event: forta_agent.transaction_event.TransactionEvent):
+def cache_contract_creation(
+    w3, transaction_event: forta_agent.transaction_event.TransactionEvent
+):
     global CREATED_CONTRACTS
     global MUTEX
 
     logging.info(
-        f"Scanning transaction {transaction_event.transaction.hash} on chain {w3.eth.chain_id}")
+        f"Scanning transaction {transaction_event.transaction.hash} on chain {w3.eth.chain_id}"
+    )
     while MUTEX:
+        logging.info(f"Sleeping...")
         time.sleep(1)  # 1 sec
 
     MUTEX = True
@@ -142,121 +182,197 @@ def cache_contract_creation(w3, blockexplorer, transaction_event: forta_agent.tr
         )
 
         logging.info(
-            f"Added contract {created_contract_address} to cache. Timestamp: {transaction_event.timestamp}")
+            f"Added contract {created_contract_address} to cache. Timestamp: {transaction_event.timestamp}"
+        )
         CREATED_CONTRACTS[created_contract_address] = transaction_event
 
     for trace in transaction_event.traces:
-        if trace.type == 'create':
-            if (transaction_event.from_ == trace.action.from_ or trace.action.from_ in created_contract_addresses):
-
+        if trace.type == "create":
+            if (
+                transaction_event.from_ == trace.action.from_
+                or trace.action.from_ in created_contract_addresses
+            ):
                 # for contracts creating other contracts, the nonce would be 1
-                nonce = transaction_event.transaction.nonce if transaction_event.from_ == trace.action.from_ else 1
+                nonce = (
+                    transaction_event.transaction.nonce
+                    if transaction_event.from_ == trace.action.from_
+                    else 1
+                )
                 created_contract_address = calc_contract_address(
-                    w3, trace.action.from_, nonce)
+                    w3, trace.action.from_, nonce
+                )
                 logging.info(
-                    f"Added contract {created_contract_address} to cache. Timestamp: {transaction_event.timestamp}")
+                    f"Added contract {created_contract_address} to cache. Timestamp: {transaction_event.timestamp}"
+                )
 
                 CREATED_CONTRACTS[created_contract_address] = transaction_event
     MUTEX = False
+    contracts_count = len(CREATED_CONTRACTS.items())
+    logging.info(f"Created Contracts Count = {contracts_count}")
 
 
-def detect_unverified_contract_creation(w3, blockexplorer, wait_time=WAIT_TIME, infinite=True):
+def detect_unverified_contract_creation(
+    w3, blockexplorer, wait_time=WAIT_TIME, infinite=True
+):
     global CREATED_CONTRACTS
     global FINDINGS_CACHE
     global MUTEX
 
     try:
-        while (True):
+        while True:
             if not MUTEX:
                 MUTEX = True
-                for created_contract_address, transaction_event in CREATED_CONTRACTS.items():
+                # logging.info(f"In detect_unverified MUtex was set to: {MUTEX}")
+                for (
+                    created_contract_address,
+                    transaction_event,
+                ) in CREATED_CONTRACTS.items():
                     logging.info(
-                        f"Evaluating contract {created_contract_address} from cache.")
+                        f"Evaluating contract {created_contract_address} from cache."
+                    )
                     created_contract_addresses = []
                     if transaction_event.to is None:
                         logging.info(
-                            f"Contract {created_contract_address} created by EOA.")
+                            f"Contract {created_contract_address} created by EOA."
+                        )
                         nonce = transaction_event.transaction.nonce
                         created_contract_address = calc_contract_address(
                             w3, transaction_event.from_, nonce
                         )
-                        if (datetime.now() - datetime.fromtimestamp(transaction_event.timestamp)) > timedelta(minutes=wait_time):
+                        if (
+                            datetime.now()
+                            - datetime.fromtimestamp(transaction_event.timestamp)
+                        ) > timedelta(minutes=wait_time):
                             logging.info(
-                                f"Evaluating contract {created_contract_address} from cache. Is old enough.")
+                                f"Evaluating contract {created_contract_address} from cache. Is old enough."
+                            )
                             if not blockexplorer.is_verified(created_contract_address):
                                 logging.info(
-                                    f"Identified unverified contract: {created_contract_address}")
+                                    f"Identified unverified contract: {created_contract_address}"
+                                )
+
                                 storage_addresses = get_storage_addresses(
-                                    w3, created_contract_address)
+                                    w3, created_contract_address
+                                )
+
                                 opcode_addresses = get_opcode_addresses(
-                                    w3, created_contract_address)
+                                    w3, created_contract_address
+                                )
 
                                 created_contract_addresses.append(
-                                    created_contract_address.lower())
+                                    created_contract_address.lower()
+                                )
 
-                                FINDINGS_CACHE.append(UnverifiedCodeContractFindings.unverified_code(
-                                    transaction_event.from_, created_contract_address, CHAIN_ID, set.union(storage_addresses, opcode_addresses)))
+                                FINDINGS_CACHE.append(
+                                    UnverifiedCodeContractFindings.unverified_code(
+                                        transaction_event.from_,
+                                        created_contract_address,
+                                        CHAIN_ID,
+                                        set.union(storage_addresses, opcode_addresses),
+                                    )
+                                )
+
                                 CREATED_CONTRACTS.pop(created_contract_address)
                             else:
                                 logging.info(
-                                    f"Identified verified contract: {created_contract_address}")
+                                    f"Identified verified contract: {created_contract_address}"
+                                )
 
                     for trace in transaction_event.traces:
-                        if trace.type == 'create':
+                        if trace.type == "create":
                             logging.info(
-                                f"Contract {created_contract_address} created within trace.")
+                                f"Contract {created_contract_address} created within trace."
+                            )
 
-                            if (transaction_event.from_ == trace.action.from_ or trace.action.from_ in created_contract_addresses):
+                            if (
+                                transaction_event.from_ == trace.action.from_
+                                or trace.action.from_ in created_contract_addresses
+                            ):
                                 # for contracts creating other contracts, the nonce would be 1
-                                nonce = transaction_event.transaction.nonce if transaction_event.from_ == trace.action.from_ else 1
+                                nonce = (
+                                    transaction_event.transaction.nonce
+                                    if transaction_event.from_ == trace.action.from_
+                                    else 1
+                                )
                                 calc_created_contract_address = calc_contract_address(
-                                    w3, trace.action.from_, nonce)
-                                if (created_contract_address == calc_created_contract_address):
-                                    if (datetime.now() - datetime.fromtimestamp(transaction_event.timestamp)) > timedelta(minutes=wait_time):
+                                    w3, trace.action.from_, nonce
+                                )
+                                if (
+                                    created_contract_address
+                                    == calc_created_contract_address
+                                ):
+                                    if (
+                                        datetime.now()
+                                        - datetime.fromtimestamp(
+                                            transaction_event.timestamp
+                                        )
+                                    ) > timedelta(minutes=wait_time):
                                         logging.info(
-                                            f"Evaluating contract {created_contract_address} from cache. Is old enough.")
-                                        if not blockexplorer.is_verified(created_contract_address):
+                                            f"Evaluating contract {created_contract_address} from cache. Is old enough."
+                                        )
+                                        if not blockexplorer.is_verified(
+                                            created_contract_address
+                                        ):
                                             logging.info(
-                                                f"Identified unverified contract: {created_contract_address}")
+                                                f"Identified unverified contract: {created_contract_address}"
+                                            )
                                             storage_addresses = get_storage_addresses(
-                                                w3, created_contract_address)
+                                                w3, created_contract_address
+                                            )
+
                                             opcode_addresses = get_opcode_addresses(
-                                                w3, created_contract_address)
+                                                w3, created_contract_address
+                                            )
 
                                             created_contract_addresses.append(
-                                                created_contract_address.lower())
+                                                created_contract_address.lower()
+                                            )
 
-                                            FINDINGS_CACHE.append(UnverifiedCodeContractFindings.unverified_code(
-                                                trace.action.from_, created_contract_address, CHAIN_ID, set.union(storage_addresses, opcode_addresses)))
+                                            FINDINGS_CACHE.append(
+                                                UnverifiedCodeContractFindings.unverified_code(
+                                                    trace.action.from_,
+                                                    created_contract_address,
+                                                    CHAIN_ID,
+                                                    set.union(
+                                                        storage_addresses,
+                                                        opcode_addresses,
+                                                    ),
+                                                )
+                                            )
                                             CREATED_CONTRACTS.pop(
-                                                created_contract_address)
+                                                created_contract_address
+                                            )
                                         else:
                                             logging.info(
-                                                f"Identified verified contract: {created_contract_address}")
+                                                f"Identified verified contract: {created_contract_address}"
+                                            )
                 if not infinite:
                     break
                 MUTEX = False
 
     except Exception as e:
-        logging.warn(f"Exception: {e}")
+        logging.warning(f"Exception: {e}")
         MUTEX = False
 
 
 def provide_handle_transaction(w3, blockexplorer):
-    def handle_transaction(transaction_event: forta_agent.transaction_event.TransactionEvent) -> list:
+    def handle_transaction(
+        transaction_event: forta_agent.transaction_event.TransactionEvent,
+    ) -> list:
         global FINDINGS_CACHE
         global THREAD_STARTED
 
         if not THREAD_STARTED:
             THREAD_STARTED = True
             thread = threading.Thread(
-                target=detect_unverified_contract_creation, args=(w3, blockexplorer))
+                target=detect_unverified_contract_creation, args=(w3, blockexplorer)
+            )
             thread.start()
 
-        cache_contract_creation(w3, blockexplorer, transaction_event)
+        cache_contract_creation(w3, transaction_event)
         # uncomment for local testing; otherwise the process will exit
-        # while (thread.is_alive()):
-        #    pass
+        while thread.is_alive():
+            pass
 
         findings = FINDINGS_CACHE
         FINDINGS_CACHE = []
@@ -268,5 +384,7 @@ def provide_handle_transaction(w3, blockexplorer):
 real_handle_transaction = provide_handle_transaction(web3, blockexplorer)
 
 
-def handle_transaction(transaction_event: forta_agent.transaction_event.TransactionEvent):
+def handle_transaction(
+    transaction_event: forta_agent.transaction_event.TransactionEvent,
+):
     return real_handle_transaction(transaction_event)

--- a/unverified-contract-py/src/agent_test.py
+++ b/unverified-contract-py/src/agent_test.py
@@ -1,11 +1,15 @@
 import time
 from datetime import datetime
 
-from forta_agent import FindingSeverity, FindingType, create_transaction_event, EntityType
+from forta_agent import (
+    FindingSeverity,
+    FindingType,
+    create_transaction_event,
+    EntityType,
+)
 import agent
 from blockexplorer_mock import BlockExplorerMock
-from web3_mock import (CONTRACT_NO_ADDRESS, CONTRACT_WITH_ADDRESS, EOA_ADDRESS,
-                       Web3Mock)
+from web3_mock import CONTRACT_NO_ADDRESS, CONTRACT_WITH_ADDRESS, EOA_ADDRESS, Web3Mock
 from unittest.mock import patch
 
 w3 = Web3Mock()
@@ -35,7 +39,9 @@ class TestUnverifiedContractAgent:
 
     def test_calc_contract_address(self):
         contract_address = agent.calc_contract_address(w3, EOA_ADDRESS, 9)
-        assert contract_address == "0x728ad672409DA288cA5B9AA85D1A55b803bA97D7", "should be the same contract address"
+        assert (
+            contract_address == "0x728ad672409DA288cA5B9AA85D1A55b803bA97D7"
+        ), "should be the same contract address"
 
     @patch("src.findings.calculate_alert_rate", return_value=1.0)
     def test_detect_unverified_contract_with_unverified_contract_no_trace(self, mocker):
@@ -48,134 +54,167 @@ class TestUnverifiedContractAgent:
                     "from": EOA_ADDRESS,
                     "nonce": 9,
                 },
-                'block': {
-                    'number': 0,
-                    'timestamp': datetime.now().timestamp(),
+                "block": {
+                    "number": 0,
+                    "timestamp": datetime.now().timestamp(),
                 },
                 "receipt": {"logs": []},
             }
         )
-        agent.cache_contract_creation(w3, blockexplorer, tx_event)
-        time.sleep(1 * 60 + 10)
+        agent.cache_contract_creation(w3, tx_event)
+        time.sleep(2)
         agent.detect_unverified_contract_creation(
-            w3, blockexplorer, wait_time=1, infinite=False)
+            w3, blockexplorer, wait_time=0, infinite=False
+        )
         assert len(agent.FINDINGS_CACHE) == 1, "should have 1 finding"
-        assert agent.FINDINGS_CACHE[0].metadata["anomaly_score"] == 1.0, "should have anomaly score of 1.0"
-        assert agent.FINDINGS_CACHE[0].labels[0].toDict(
-        )["entity"] == EOA_ADDRESS, "should have EOA address as label"
-        assert agent.FINDINGS_CACHE[0].labels[0].toDict(
-        )["entity_type"] == EntityType.Address, "should have label_type address"
-        assert agent.FINDINGS_CACHE[0].labels[0].toDict(
-        )["label"] == 'attacker', "should have attacker as label"
-        assert agent.FINDINGS_CACHE[0].labels[0].toDict(
-        )["confidence"] == 0.3, "should have 0.3 as label confidence"
-        assert agent.FINDINGS_CACHE[0].labels[1].toDict(
-        )["entity"] == '0x728ad672409DA288cA5B9AA85D1A55b803bA97D7', "should have contract address as label"
-        assert agent.FINDINGS_CACHE[0].labels[1].toDict(
-        )["label"] == 'attacker_contract', "should have attacker as label"
-        assert agent.FINDINGS_CACHE[0].labels[1].toDict(
-        )["confidence"] == 0.3, "should have 0.3 as label confidence"
-        assert agent.FINDINGS_CACHE[0].labels[1].toDict(
-        )["entity_type"] == EntityType.Address, "should have label_type address"
+        assert (
+            agent.FINDINGS_CACHE[0].metadata["anomaly_score"] == 1.0
+        ), "should have anomaly score of 1.0"
+        assert (
+            agent.FINDINGS_CACHE[0].labels[0].toDict()["entity"] == EOA_ADDRESS
+        ), "should have EOA address as label"
+        assert (
+            agent.FINDINGS_CACHE[0].labels[0].toDict()["entity_type"]
+            == EntityType.Address
+        ), "should have label_type address"
+        assert (
+            agent.FINDINGS_CACHE[0].labels[0].toDict()["label"] == "attacker"
+        ), "should have attacker as label"
+        assert (
+            agent.FINDINGS_CACHE[0].labels[0].toDict()["confidence"] == 0.3
+        ), "should have 0.3 as label confidence"
+        assert (
+            agent.FINDINGS_CACHE[0].labels[1].toDict()["entity"]
+            == "0x728ad672409DA288cA5B9AA85D1A55b803bA97D7"
+        ), "should have contract address as label"
+        assert (
+            agent.FINDINGS_CACHE[0].labels[1].toDict()["label"] == "attacker_contract"
+        ), "should have attacker as label"
+        assert (
+            agent.FINDINGS_CACHE[0].labels[1].toDict()["confidence"] == 0.3
+        ), "should have 0.3 as label confidence"
+        assert (
+            agent.FINDINGS_CACHE[0].labels[1].toDict()["entity_type"]
+            == EntityType.Address
+        ), "should have label_type address"
 
     def test_detect_unverified_contract_with_unverified_contract_trace(self):
         agent.initialize()
 
-        tx_event = create_transaction_event({
+        tx_event = create_transaction_event(
+            {
+                "transaction": {
+                    "hash": "0",
+                    "from": EOA_ADDRESS,
+                    "to": "0x0000000000000000000000000000000000000000",
+                    "nonce": 9,
+                },
+                "block": {
+                    "number": 0,
+                    "timestamp": datetime.now().timestamp(),
+                },
+                "traces": [
+                    {
+                        "type": "create",
+                        "action": {
+                            "from": EOA_ADDRESS,
+                            "value": 1,
+                        },
+                    }
+                ],
+                "receipt": {"logs": []},
+            }
+        )
 
-            'transaction': {
-                'hash': "0",
-                'from': EOA_ADDRESS,
-                'to': '0x0000000000000000000000000000000000000000',
-                'nonce': 9,
-
-            },
-            'block': {
-                'number': 0,
-                'timestamp': datetime.now().timestamp(),
-            },
-            'traces': [{'type': 'create',
-                        'action': {
-                            'from': EOA_ADDRESS,
-                            'value': 1,
-                        }
-                        }
-                       ],
-            'receipt': {
-                'logs': []}
-        })
-
-        agent.cache_contract_creation(w3, blockexplorer, tx_event)
-        time.sleep(1 * 60 + 10)
+        agent.cache_contract_creation(w3, tx_event)
+        time.sleep(2)
         agent.detect_unverified_contract_creation(
-            w3, blockexplorer, wait_time=1, infinite=False)
+            w3, blockexplorer, wait_time=0, infinite=False
+        )
         assert len(agent.FINDINGS_CACHE) == 1, "should have 1 finding"
-        finding = next((x for x in agent.FINDINGS_CACHE if x.alert_id ==
-                       'UNVERIFIED-CODE-CONTRACT-CREATION'), None)
+        finding = next(
+            (
+                x
+                for x in agent.FINDINGS_CACHE
+                if x.alert_id == "UNVERIFIED-CODE-CONTRACT-CREATION"
+            ),
+            None,
+        )
         assert finding.severity == FindingSeverity.Medium
         assert finding.type == FindingType.Suspicious
-        assert finding.description == f'{EOA_ADDRESS} created contract 0x728ad672409DA288cA5B9AA85D1A55b803bA97D7'
+        assert (
+            finding.description
+            == f"{EOA_ADDRESS} created contract 0x728ad672409DA288cA5B9AA85D1A55b803bA97D7"
+        )
         assert len(finding.metadata) > 0
 
     def test_detect_unverified_contract_with_verified_contract(self):
         agent.initialize()
 
-        tx_event = create_transaction_event({
-            'transaction': {
-                'hash': "0",
-                'from': EOA_ADDRESS,
-                'nonce': 10,  # verified contract
-            },
-            'block': {
-                'number': 0,
-                'timestamp': datetime.now().timestamp(),
-            },
-            'traces': [{'type': 'create',
-                        'action': {
-                            'from': EOA_ADDRESS,
-                            'value': 1,
-                        }
-                        }
-                       ],
-            'receipt': {
-                'logs': []}
-        })
+        tx_event = create_transaction_event(
+            {
+                "transaction": {
+                    "hash": "0",
+                    "from": EOA_ADDRESS,
+                    "nonce": 10,  # verified contract
+                },
+                "block": {
+                    "number": 0,
+                    "timestamp": datetime.now().timestamp(),
+                },
+                "traces": [
+                    {
+                        "type": "create",
+                        "action": {
+                            "from": EOA_ADDRESS,
+                            "value": 1,
+                        },
+                    }
+                ],
+                "receipt": {"logs": []},
+            }
+        )
 
-        agent.cache_contract_creation(w3, blockexplorer, tx_event)
-        time.sleep(1 * 60 + 10)
+        agent.cache_contract_creation(w3, tx_event)
+        time.sleep(2)
         agent.detect_unverified_contract_creation(
-            w3, blockexplorer, wait_time=1, infinite=False)
+            w3, blockexplorer, wait_time=0, infinite=False
+        )
 
         assert len(agent.FINDINGS_CACHE) == 0, "should have 0 finding"
 
     def test_detect_unverified_contract_call_only(self):
         agent.initialize()
 
-        tx_event = create_transaction_event({
-            'transaction': {
-                'hash': "0",
-                'from': EOA_ADDRESS,
-                'nonce': 7,
-                'to': '0x0000000000000000000000000000000000000000'
-            },
-            'block': {
-                'number': 0,
-                'timestamp': datetime.now().timestamp(),
-            },
-            'traces': [{'type': 'call',
-                        'action': {
-                            'from': EOA_ADDRESS,
-                            'to': '0x728ad672409DA288cA5B9AA85D1A55b803bA97D7',  # unverified contract
-                            'value': 1,
-                        }
-                        }
-                       ],
-            'receipt': {
-                'logs': []}
-        })
+        tx_event = create_transaction_event(
+            {
+                "transaction": {
+                    "hash": "0",
+                    "from": EOA_ADDRESS,
+                    "nonce": 7,
+                    "to": "0x0000000000000000000000000000000000000000",
+                },
+                "block": {
+                    "number": 0,
+                    "timestamp": datetime.now().timestamp(),
+                },
+                "traces": [
+                    {
+                        "type": "call",
+                        "action": {
+                            "from": EOA_ADDRESS,
+                            "to": "0x728ad672409DA288cA5B9AA85D1A55b803bA97D7",  # unverified contract
+                            "value": 1,
+                        },
+                    }
+                ],
+                "receipt": {"logs": []},
+            }
+        )
 
-        agent.cache_contract_creation(w3, blockexplorer, tx_event)
-        time.sleep(1 * 60 + 10)
+        agent.cache_contract_creation(w3, tx_event)
+        time.sleep(2)
         agent.detect_unverified_contract_creation(
-            w3, blockexplorer, wait_time=1, infinite=False)
+            w3, blockexplorer, wait_time=0, infinite=False
+        )
         assert len(agent.FINDINGS_CACHE) == 0, "should have 0 finding"

--- a/unverified-contract-py/src/constants.py
+++ b/unverified-contract-py/src/constants.py
@@ -1,2 +1,3 @@
 CONTRACT_SLOT_ANALYSIS_DEPTH = 20  # how many slots should be read to extract contract addresses from created contract
 WAIT_TIME = 30  # how many minutes after contract creation we will wait for the creator to share source code on etherscan
+CONCURRENT_SIZE = 5  # how many concurrent connections should be made.


### PR DESCRIPTION
- Added `try-except` block for `is_contract` method so that the entire transaction won't be dropper when the method throws an error.
- Added LRU-Cache for `is_contract` method.
- Used concurrent threads to execute `get_storage_at` method. 
- Added sharding configuration for the chains: Ethereum, OP, Arbitrum, Fantom, Avalanche
- Updated test file by adjusting the sleep timing for each test.
- Added an additional example test transaction to read me.

Related issue: https://github.com/forta-network/starter-kits/issues/188