### PR TITLE
Remove redundancy propagation

### DIFF
--- a/scammer-label-propagation/package-lock.json
+++ b/scammer-label-propagation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scammer-label-propagation",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scammer-label-propagation",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "hasInstallScript": true,
       "dependencies": {
         "forta-agent": "^0.1.34"

--- a/scammer-label-propagation/package.json
+++ b/scammer-label-propagation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scammer-label-propagation",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Scammer label propagation bot",
   "repository": "https://github.com/forta-network/starter-kits/tree/main/scammer-label-propagation",
   "chainIds": [

--- a/scammer-label-propagation/publish.log
+++ b/scammer-label-propagation/publish.log
@@ -18,3 +18,4 @@ Wed, 26 Jul 2023 06:14:48 GMT: successfully updated agent id 0xcd9988f3d5c993592
 Tue, 01 Aug 2023 18:09:59 GMT: successfully updated agent id 0xcd9988f3d5c993592b61048628c28a7424235794ada5dc80d55eeb70ec513848 with manifest QmYzPuVAMb4jAJP4GcLUjUjhYsYeC9PH65oC4xdgWqttd8
 Fri, 04 Aug 2023 10:18:29 GMT: successfully updated agent id 0xcd9988f3d5c993592b61048628c28a7424235794ada5dc80d55eeb70ec513848 with manifest QmbmJhJt4AmaFZJFBSm9NqXGuYeMVBeN5zjosbC1d1so4o
 Thu, 10 Aug 2023 13:10:40 GMT: successfully updated agent id 0xcd9988f3d5c993592b61048628c28a7424235794ada5dc80d55eeb70ec513848 with manifest QmZczXEt9eSQu2uUKapjVhEe139E1nvuwQNE3pcVZHFm2F
+Mon, 28 Aug 2023 08:01:52 GMT: successfully updated agent id 0xcd9988f3d5c993592b61048628c28a7424235794ada5dc80d55eeb70ec513848 with manifest QmSEyctghTYDLDhckyZBboQzmCzAQfzvsVeAsYw6dnDoAg

--- a/scammer-label-propagation/src/agent.py
+++ b/scammer-label-propagation/src/agent.py
@@ -185,8 +185,8 @@ def provide_handle_alert(w3):
         global global_futures
 
         list_of_addresses = []
-        if alert_event.alert.alert_id == 'SCAM-DETECTOR-ADDRESS-POISONING':
-            logger.debug(f"Address poisoning. Addresses: {';'.join([label.entity for label in alert_event.alert.labels])}")
+        if alert_event.alert.alert_id in ['SCAM-DETECTOR-ADDRESS-POISONING', 'SCAM-DETECTOR-SCAMMER-ASSOCIATION']:
+            logger.debug(f"Invalid alert id. Addresses: {';'.join([label.entity for label in alert_event.alert.labels])}")
             return []
         for label in alert_event.alert.labels:
             # if label.confidence >= ATTACKER_CONFIDENCE and label.entity_type == forta_agent.EntityType.Address:


### PR DESCRIPTION
Sometimes the tag SCAM-DETECTOR-SCAMMER-ASSOCIATION was passing some addresses, and those would be analyzed, creating a chain reaction. This PR solves that issue by filtering out labels with that id