### PR TITLE
Create positive reputation by age

### DIFF
--- a/alert-combiner-py/README.md
+++ b/alert-combiner-py/README.md
@@ -415,5 +415,6 @@ The following bots are used to mitigate FPs:
 | 0xabdeff7672e59d53c7702777652e318ada644698a9faf2e7f608ec846b07325b | MEV account bot | MEV-ACCOUNT |
 | 0xa91a31df513afff32b9d85a2c2b7e786fdd681b3cdd8d93d6074943ba31ae400 | High funding activity through TC | FUNDING-TORNADO-CASH-HIGH |
 | 0xd6e19ec6dc98b13ebb5ec24742510845779d9caf439cadec9a5533f8394d435f | Positive reputation bot | POSITIVE-REPUTATION-1 |
+| 0xd6e19ec6dc98b13ebb5ec24742510845779d9caf439cadec9a5533f8394d435f | Positive reputation bot | POSITIVE-REPUTATION-2 |
 | 0xe04b3fa79bd6bc6168a211bcec5e9ac37d5dd67a41a1884aa6719f8952fbc274 | Victim Notification bot | VICTIM-NOTIFICATION-1 |
 In addtion, Etherscan tags are used for FP mitigation.

--- a/alert-combiner-py/src/constants.py
+++ b/alert-combiner-py/src/constants.py
@@ -27,6 +27,7 @@ TX_COUNT_FILTER_THRESHOLD = 500  # ignore EOAs with tx count larger than this th
 FP_MITIGATION_BOTS = [("0xabdeff7672e59d53c7702777652e318ada644698a9faf2e7f608ec846b07325b", "MEV-ACCOUNT"),
                       ("0xa91a31df513afff32b9d85a2c2b7e786fdd681b3cdd8d93d6074943ba31ae400", "FUNDING-TORNADO-CASH-HIGH"),
                       ("0xd6e19ec6dc98b13ebb5ec24742510845779d9caf439cadec9a5533f8394d435f", "POSITIVE-REPUTATION-1"),
+                      ("0xd6e19ec6dc98b13ebb5ec24742510845779d9caf439cadec9a5533f8394d435f", "POSITIVE-REPUTATION-2"),
                       ("0xe04b3fa79bd6bc6168a211bcec5e9ac37d5dd67a41a1884aa6719f8952fbc274", "VICTIM-NOTIFICATION-1")
                       ]
 

--- a/positive-reputation-py/README.md
+++ b/positive-reputation-py/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This bot identifies EOA associated with positive reputation in context of an attack (aka unlikely to be an attacker). The alert from this bot can be useful in context of FP mitigations. 
+This bot identifies EOA associated with positive reputation in context of an attack (aka unlikely to be an attacker). The alert from this bot can be useful in context of FP mitigations.
 
 The current implementation merely looks at the nonce and age
 
@@ -13,9 +13,14 @@ The current implementation merely looks at the nonce and age
 ## Alerts
 
 - POSITIVE-REPUTATION-1
-  - Fired when an EOA with positive reputation has been identified
-  - Severity is always set to "info" 
-  - Type is always set to "info" 
+  - Fired when an EOA with positive reputation has been identified by both nonce and age
+  - Severity is always set to "info"
+  - Type is always set to "info"
+
+- POSITIVE-REPUTATION-2
+  - Fired when an EOA with positive reputation has been identified by merely age
+  - Severity is always set to "info"
+  - Type is always set to "info"
 
 ## Test Data
 

--- a/positive-reputation-py/src/agent_test.py
+++ b/positive-reputation-py/src/agent_test.py
@@ -84,3 +84,25 @@ class TestPositiveReputation:
 
         findings = agent.detect_positive_reputation(w3, blockexplorer, tx_event)
         assert len(findings) == 0, "Bot incorrectly detected positive reputation"
+
+    def test_detect_positive_reputation_by_age(self):
+        agent.item_id_prefix = "test_" + str(random.randint(0, 1000000))
+        agent.initialize()
+        tx_event = create_transaction_event({
+            'transaction': {
+                'hash': "0",
+                'from': EOA_ADDRESS_OLD,
+                'value': 0,
+                'to': "",
+                'nonce': 10,
+            },
+            'block': {
+                'number': 0
+            },
+            'logs': [],
+            'receipt': {
+                'logs': []}
+        })
+
+        findings = agent.detect_positive_reputation(w3, blockexplorer, tx_event)
+        assert len(findings) == 1, "Bot didnt successfully detect positive reputation by age"

--- a/positive-reputation-py/src/findings.py
+++ b/positive-reputation-py/src/findings.py
@@ -39,3 +39,37 @@ class PositiveReputationFindings:
             'metadata': metadata
         })
         return finding
+
+    @staticmethod
+    def positive_reputation_by_age(address: str, chain_id: int) -> Finding:
+        labels = []
+        labels.append(Label({
+            'entityType': EntityType.Address,
+            'label': "benign",
+            'entity': address,
+            'confidence': 0.80,
+            'metadata': {
+                'alert_id': 'POSITIVE-REPUTATION-2',
+                'chain_id': chain_id
+            }
+        }))
+
+        metadata = {}
+
+        if chain_id not in [43114, 10, 250]:
+            metadata['anomaly_score'] = calculate_alert_rate(
+                chain_id,
+                BOT_ID,
+                'POSITIVE-REPUTATION-2',
+                ScanCountType.TX_COUNT)
+
+        finding = Finding({
+            'name': 'Positive Reputation',
+            'description': f'{address} has positive reputation',
+            'alert_id': 'POSITIVE-REPUTATION-2',
+            'type': FindingType.Info,
+            'severity': FindingSeverity.Info,
+            'labels': labels,
+            'metadata': metadata
+        })
+        return finding


### PR DESCRIPTION
Added another alert into positive reputation bot that only marks an address if it has low nonce but is old enough. which means it's probably safe.

alert id: POSITIVE-REPUTATION-2

this id is added into the attack detector's fp mitigation bots

related issue: https://github.com/forta-network/starter-kits/issues/269

