### PR TITLE
Positive reputation sharding

### DIFF
--- a/positive-reputation-py/package.json
+++ b/positive-reputation-py/package.json
@@ -1,6 +1,6 @@
 {
   "name": "positive-reputation-bot",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "repository": "https://github.com/forta-network/starter-kits/tree/main/positive-reputation-py",
   "description": "Positive Reputation Bot",
   "chainIds": [

--- a/positive-reputation-py/package.json
+++ b/positive-reputation-py/package.json
@@ -6,6 +6,20 @@
   "chainIds": [
     1, 56, 137, 43114, 42161, 10, 250
   ],
+  "chainSettings": {
+    "1": {
+      "shards": 3,
+      "target": 3
+    },
+    "56": {
+      "shards": 3,
+      "target": 3
+    },
+    "default": {
+      "shards": 2,
+      "target": 3
+    }
+  },
   "scripts": {
     "postinstall": "python3 -m pip install -r requirements_dev.txt",
     "start": "npm run start:dev",

--- a/positive-reputation-py/src/agent.py
+++ b/positive-reputation-py/src/agent.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from os import environ
+from functools import lru_cache
 
 import forta_agent
 from forta_agent import get_json_rpc_url
@@ -93,7 +94,7 @@ def put_first_tx(address: str, first_tx_datetime: datetime):
         logging.info(f"Successfully put first tx in dynamoDB: {response}")
         return
 
-
+@lru_cache(maxsize=12800)
 def read_first_tx(address: str):
     global CHAIN_ID
 
@@ -142,7 +143,7 @@ def put_pos_rep_address(address: str):
         logging.info(f"Successfully put pos rep address in dynamoDB: {response}")
         return
 
-
+@lru_cache(maxsize=12800)
 def read_pos_rep(address: str) -> bool:
     global CHAIN_ID
 

--- a/positive-reputation-py/src/agent.py
+++ b/positive-reputation-py/src/agent.py
@@ -166,9 +166,9 @@ def read_pos_rep(address: str) -> bool:
 
 
 def detect_positive_reputation(w3, blockexplorer, transaction_event: forta_agent.transaction_event.TransactionEvent) -> list:
-    logging.info(f"Analyzing transaction {transaction_event.transaction.hash} on chain {w3.eth.chain_id}")
-
     global CHAIN_ID
+    logging.info(f"Analyzing transaction {transaction_event.transaction.hash} on chain {CHAIN_ID}")
+
     findings = []
 
     # get the nonce of the sender


### PR DESCRIPTION
Related issue: https://github.com/forta-network/starter-kits/issues/311

- Replaced redundant and repetitive rpc calls with a variable
- Added lrc-cache to `read_first_tx` and `read_pos_rep`
- Created sharding settings