### PR TITLE
AD FP on Polygon Validators

### DIFF
--- a/alert-combiner-py/src/agent.py
+++ b/alert-combiner-py/src/agent.py
@@ -224,13 +224,18 @@ def get_anomaly_score(alert_event: forta_agent.alert_event.AlertEvent) -> float:
 
 def is_polygon_validator(w3, cluster: str, tx_hash: str) -> bool:
     if CHAIN_ID == 137:
-        tx = w3.eth.get_transaction_receipt(tx_hash)
-        for log in tx['logs']:
-            if len(log['topics']) > 3:
-                if log['topics'][0] == HexBytes('0x4dfe1bbbcf077ddc3e01291eea2d5c70c2b422b415d95645b9adcfd678cb1d63'):  # logfeetransfer event
-                    validator = log['topics'][3].hex()[-40:]  # validator in 3rd pos
-                    if validator in cluster:
-                        return True
+        try:
+            tx = w3.eth.get_transaction_receipt(tx_hash)
+            for log in tx['logs']:
+                if len(log['topics']) > 3:
+                    if log['topics'][0] == HexBytes('0x4dfe1bbbcf077ddc3e01291eea2d5c70c2b422b415d95645b9adcfd678cb1d63'):  # logfeetransfer event
+                        validator = log['topics'][3].hex()[-40:]  # validator in 3rd pos
+                        if validator in cluster:
+                            return True
+        except Exception as e:
+            logging.error(f"Error fetching transaction receipt: {e}")
+            return True # assume validator if error, to avoid false positives
+
     return False
 
 def get_end_user_attack_addresses(alert_event: forta_agent.alert_event.AlertEvent) -> list:


### PR DESCRIPTION
related issue: https://github.com/forta-network/starter-kits/issues/270

`w3.eth.get_transaction_receipt` function normally either returns the tx receipt or throws `web3.exceptions.TransactionNotFound`. [docs](https://web3py.readthedocs.io/en/latest/web3.eth.html#web3.eth.Eth.get_transaction_receipt)
when it can't fetch the receipt properly, the default `is_polygon_validator` variable is set to False, which causes an FP. 
I added a try catch block to handle errors by assuming the address is a validator address, to mitigate a possible FP. 
and also added an error log there to see how often `w3.eth.get_transaction_receipt` throws an error

