### PR TITLE
Unique key for labels

### DIFF
--- a/scam-detector-py/src/findings_test.py
+++ b/scam-detector-py/src/findings_test.py
@@ -4,6 +4,7 @@ from forta_agent import FindingSeverity, FindingType, EntityType
 from blockchain_indexer_mock import BlockChainIndexerMock
 from forta_explorer_mock import FortaExplorerMock
 import pandas as pd
+import hashlib
 
 from src.findings import ScamDetectorFinding
 from src.utils import Utils
@@ -59,6 +60,7 @@ class TestScamFindings:
         assert finding.labels[0].metadata["base_bot_alert_ids"] == "ICE-PHISHING"
         assert finding.labels[0].metadata["base_bot_alert_hashes"] == "0xabc"
         assert finding.labels[0].metadata["threat_description_url"] == ScamDetectorFinding.get_threat_description_url(alert_id)
+        assert finding.labels[0].unique_key == hashlib.sha256(f'{EOA_ADDRESS_SMALL_TX},{alert_id},{chain_id}'.encode()).hexdigest()
 
         assert finding.labels[1].entity_type == EntityType.Address
         assert finding.labels[1].entity == CONTRACT
@@ -70,6 +72,7 @@ class TestScamFindings:
         assert finding.labels[1].metadata["base_bot_alert_ids"] == "ICE-PHISHING"
         assert finding.labels[1].metadata["base_bot_alert_hashes"] == "0xabc"
         assert finding.labels[1].metadata["threat_description_url"] == ScamDetectorFinding.get_threat_description_url(alert_id)
+        assert finding.labels[1].unique_key == hashlib.sha256(f'{CONTRACT},{alert_id},{chain_id}'.encode()).hexdigest()
 
     def test_scam_finding_with_url(self):
         start_date = datetime(2021, 1, 1)


### PR DESCRIPTION
Related issue: https://github.com/forta-network/starter-kits/issues/347

- in `scam_finding` 3 unique keys are added for 3 different entities (scammer, contract and url)
- test assertions for the unique keys are added