### PR TITLE
Entity Cluster - Missing Funder in Cluster

### DIFF
--- a/entity-cluster-bot/package-lock.json
+++ b/entity-cluster-bot/package-lock.json
@@ -953,11 +953,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
+      "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1081,19 +1083,22 @@
       }
     },
     "node_modules/browserify-sign": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+      "integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
       "dependencies": {
-        "bn.js": "^5.1.1",
-        "browserify-rsa": "^4.0.1",
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.4",
         "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "parse-asn1": "^5.1.6",
+        "readable-stream": "^3.6.2",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/buffer": {
@@ -1447,9 +1452,9 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",
@@ -1479,16 +1484,16 @@
       }
     },
     "node_modules/forta-agent": {
-      "version": "0.1.39",
-      "resolved": "https://registry.npmjs.org/forta-agent/-/forta-agent-0.1.39.tgz",
-      "integrity": "sha512-LsR/WaUg46AO9IyCxmCp6oYyZjf/eQmsfvQziINByO7DNAdvF9l+/TH19sIpwHVT19RlXmwC4RH9Fbm3jnHNcw==",
+      "version": "0.1.48",
+      "resolved": "https://registry.npmjs.org/forta-agent/-/forta-agent-0.1.48.tgz",
+      "integrity": "sha512-fk3mar7/Avqg/4OHFmgv01ww/azr1XM+g5KcSnwvNxZy3KDMi7aFp1jAjPCsBjs8ZyVcR03ITUlbtFpRVgZB4Q==",
       "dependencies": {
         "@grpc/grpc-js": "^1.3.6",
         "@grpc/proto-loader": "^0.6.4",
         "@types/uuid": "^8.3.4",
         "async-retry": "^1.3.3",
         "awilix": "^4.3.4",
-        "axios": "^0.21.1",
+        "axios": "^1.6.2",
         "base64-arraybuffer": "^1.0.2",
         "ethers": "^5.5.1",
         "flat-cache": "^3.0.4",
@@ -2148,6 +2153,11 @@
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -3213,11 +3223,13 @@
       }
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
+      "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "balanced-match": {
@@ -3318,19 +3330,19 @@
       }
     },
     "browserify-sign": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
+      "integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
       "requires": {
-        "bn.js": "^5.1.1",
-        "browserify-rsa": "^4.0.1",
+        "bn.js": "^5.2.1",
+        "browserify-rsa": "^4.1.0",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.4",
         "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "parse-asn1": "^5.1.6",
+        "readable-stream": "^3.6.2",
+        "safe-buffer": "^5.2.1"
       }
     },
     "buffer": {
@@ -3631,9 +3643,9 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -3646,16 +3658,16 @@
       }
     },
     "forta-agent": {
-      "version": "0.1.39",
-      "resolved": "https://registry.npmjs.org/forta-agent/-/forta-agent-0.1.39.tgz",
-      "integrity": "sha512-LsR/WaUg46AO9IyCxmCp6oYyZjf/eQmsfvQziINByO7DNAdvF9l+/TH19sIpwHVT19RlXmwC4RH9Fbm3jnHNcw==",
+      "version": "0.1.48",
+      "resolved": "https://registry.npmjs.org/forta-agent/-/forta-agent-0.1.48.tgz",
+      "integrity": "sha512-fk3mar7/Avqg/4OHFmgv01ww/azr1XM+g5KcSnwvNxZy3KDMi7aFp1jAjPCsBjs8ZyVcR03ITUlbtFpRVgZB4Q==",
       "requires": {
         "@grpc/grpc-js": "^1.3.6",
         "@grpc/proto-loader": "^0.6.4",
         "@types/uuid": "^8.3.4",
         "async-retry": "^1.3.3",
         "awilix": "^4.3.4",
-        "axios": "^0.21.1",
+        "axios": "^1.6.2",
         "base64-arraybuffer": "^1.0.2",
         "ethers": "^5.5.1",
         "flat-cache": "^3.0.4",
@@ -4168,6 +4180,11 @@
         "@types/node": ">=13.7.0",
         "long": "^4.0.0"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pstree.remy": {
       "version": "1.1.8",

--- a/entity-cluster-bot/package-lock.json
+++ b/entity-cluster-bot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entity-cluster-bot",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "entity-cluster-bot",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "hasInstallScript": true,
       "dependencies": {
         "forta-agent": "^0.1.33"

--- a/entity-cluster-bot/package.json
+++ b/entity-cluster-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entity-cluster-bot",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "A bot that clusters entities",
   "chainIds": [
     1, 137, 56, 43114, 42161, 10, 250

--- a/entity-cluster-bot/package.json
+++ b/entity-cluster-bot/package.json
@@ -1,9 +1,16 @@
 {
   "name": "entity-cluster-bot",
+  "displayName": "Entity Cluster Bot",
   "version": "0.0.19",
   "description": "A bot that clusters entities",
   "chainIds": [
-    1, 137, 56, 43114, 42161, 10, 250
+    1,
+    137,
+    56,
+    43114,
+    42161,
+    10,
+    250
   ],
   "chainSettings": {
     "1": {
@@ -54,8 +61,6 @@
     "contract-creation": "forta-agent run --tx 0x43ccd83cc6059db240e7957586e3a22d0a8871e986f4325fc778943b9514ca11",
     "small-tx": "forta-agent run --tx 0x8c9b92897af9f7c93ebc6beffc1a8c6d68225b8b40ef4e276a3df83fd308e416",
     "erc-20-tx": "forta-agent run --tx 0x9ca1ae7438b939c23b69e72e740615f2d0ef4360bb06047d9201ac29baf64283"
-
-
   },
   "dependencies": {
     "forta-agent": "^0.1.33"

--- a/entity-cluster-bot/src/agent_test.py
+++ b/entity-cluster-bot/src/agent_test.py
@@ -532,7 +532,7 @@ class TestEntityClusterBot:
 
 
 
-    def test_sharding_finding_bidirectional_in_redundacy_env(self):
+    def test_sharding_finding_bidirectional_in_redundancy_env(self):
         TestEntityClusterBot.remove_persistent_state()
 
         right_addr = '0x05f75788d3ec37bc8357c9ba88054c1650dd31f5'
@@ -565,7 +565,6 @@ class TestEntityClusterBot:
         
         agent1b = EntityClusterAgent(DynamoPersistance())   
         agent1b.cluster_entities(real_w3, native_transfer1)
-        print("after cluster_entities call")
         agent1a = EntityClusterAgent(DynamoPersistance())
         findings = agent1a.cluster_entities(real_w3, native_transfer1)
         assert len(findings) == 0, "No findings should be returned as it is not bidirectional"

--- a/entity-cluster-bot/src/agent_test.py
+++ b/entity-cluster-bot/src/agent_test.py
@@ -11,6 +11,10 @@ from forta_agent import get_alerts, get_json_rpc_url
 import timeit
 
 w3 = Web3Mock()
+# NOTE: Because the bot defaults to Ethereum mainnet,
+# you need to have an ETH mainnet RPC set up in your
+# `forta.config.json` to have the tests behave as expected
+# when they use `real_w3`.
 real_w3 = Web3(Web3.HTTPProvider(get_json_rpc_url()))
 from persistance import DynamoPersistance
 
@@ -39,7 +43,7 @@ class TestEntityClusterBot:
     def test_add_address_discard(self):
         #  calls address on address with too large of a nonce
         agent = EntityClusterAgent(DynamoPersistance())
-        if agent.is_address_belong_max_transactions(w3, EOA_ADDRESS_LARGE_TX):
+        if agent.is_address_below_max_transactions(w3, EOA_ADDRESS_LARGE_TX):
             agent.add_address(EOA_ADDRESS_LARGE_TX)
 
         assert len(agent.GRAPH.nodes) == 0, "Address shouldnt have been added to graph. Its nonce is too large"
@@ -47,7 +51,7 @@ class TestEntityClusterBot:
     def test_add_address_valid(self):
         #  calls address on address with appropriate nonce
         agent = EntityClusterAgent(DynamoPersistance())
-        if agent.is_address_belong_max_transactions(w3, EOA_ADDRESS_SMALL_TX):
+        if agent.is_address_below_max_transactions(w3, EOA_ADDRESS_SMALL_TX):
             agent.add_address(EOA_ADDRESS_SMALL_TX)
 
         assert len(agent.GRAPH.nodes) == 1, "Address should have been added to graph. Its nonce is within range"
@@ -214,7 +218,7 @@ class TestEntityClusterBot:
             })
 
         findings = agent.cluster_entities(w3, native_transfer1)
-        assert len(findings) == 1, "Findings should be returned as it is new account transfer"
+        assert len(findings) == 2, "Findings should be returned as it is new account transfer"
 
     def test_finding_onedirectional_initial_funds_new_account_above_threshold(self):
         TestEntityClusterBot.remove_persistent_state()
@@ -224,7 +228,7 @@ class TestEntityClusterBot:
 
                 'transaction': {
                     'hash': "0",
-                    'from': EOA_ADDRESS_FUNDER_NEW,
+                    'from': EOA_ADDRESS_FUNDER_OLD,
                     'to': EOA_ADDRESS_FUNDED_NEW,
                     'value': 1000000000000000000
 
@@ -263,6 +267,30 @@ class TestEntityClusterBot:
 
         findings = agent.cluster_entities(w3, native_transfer1)
         assert len(findings) == 0, "No findings should be returned as it old account transfer"
+    
+    def test_finding_bidirectional_initial_funds_new_account_from_new_account_regardless_of_txn_value(self):
+        TestEntityClusterBot.remove_persistent_state()
+        agent = EntityClusterAgent(DynamoPersistance())
+
+        native_transfer1 = create_transaction_event({
+
+                'transaction': {
+                    'hash': "0",
+                    'from': EOA_ADDRESS_FUNDER_NEW, # Zero nonce
+                    'to': EOA_ADDRESS_FUNDED_NEW,   # Zero nonce
+                    'value': 5000000000000000000    # Over threshold
+
+                },
+                'block': {
+                    'number': 0,
+                    'timestamp': datetime.now().timestamp(),
+                },
+                'receipt': {
+                    'logs': []}
+            })
+
+        findings = agent.cluster_entities(w3, native_transfer1)
+        assert len(findings) == 1, "Finding should be returned as it is a transfer between two low nonce accounts, despite txn value exceededing threshold"
 
     def test_entity_cluster_perf_test(self):
         TestEntityClusterBot.remove_persistent_state()
@@ -504,11 +532,15 @@ class TestEntityClusterBot:
 
 
 
-    def test_shrading_finding_bidirectional_in_redundacy_env(self):
+    def test_sharding_finding_bidirectional_in_redundacy_env(self):
         TestEntityClusterBot.remove_persistent_state()
 
         right_addr = '0x05f75788d3ec37bc8357c9ba88054c1650dd31f5'
         left_addr = '0xB0e5DDCBAA6c3524896767872797091F04aD0e19'
+        # Because this test is making actual RPC calls on ETH mainnet,
+        # we are using a block number that will return a non-zero value
+        # for the two addresses' `transaction_count`.
+        block_number = 18127797
 
 
         
@@ -524,7 +556,7 @@ class TestEntityClusterBot:
 
                 },
                 'block': {
-                    'number': 0,
+                    'number': block_number,
                     'timestamp': datetime.now().timestamp(),
                 },
                 'receipt': {
@@ -533,6 +565,7 @@ class TestEntityClusterBot:
         
         agent1b = EntityClusterAgent(DynamoPersistance())   
         agent1b.cluster_entities(real_w3, native_transfer1)
+        print("after cluster_entities call")
         agent1a = EntityClusterAgent(DynamoPersistance())
         findings = agent1a.cluster_entities(real_w3, native_transfer1)
         assert len(findings) == 0, "No findings should be returned as it is not bidirectional"
@@ -548,7 +581,7 @@ class TestEntityClusterBot:
 
                 },
                 'block': {
-                    'number': 0,
+                    'number': block_number,
                     'timestamp': datetime.now().timestamp(),
                 },
                 'receipt': {
@@ -562,11 +595,15 @@ class TestEntityClusterBot:
         assert len(findings) == 1, "Finding should be returned as it is bidirectional"
 
 
-    def test_shrading_finding_bidirectional(self):
+    def test_sharding_finding_bidirectional(self):
         TestEntityClusterBot.remove_persistent_state()
 
         right_addr = '0x05f75788d3ec37bc8357c9ba88054c1650dd31f5'
         left_addr = '0xB0e5DDCBAA6c3524896767872797091F04aD0e19'
+        # Because this test is making actual RPC calls on ETH mainnet,
+        # we are using a block number that will return a non-zero value
+        # for the two addresses' `transaction_count`.
+        block_number = 18127797
     
         agent1 = EntityClusterAgent(DynamoPersistance())
 
@@ -582,7 +619,7 @@ class TestEntityClusterBot:
 
                 },
                 'block': {
-                    'number': 0,
+                    'number': block_number,
                     'timestamp': datetime.now().timestamp(),
                 },
                 'receipt': {
@@ -602,7 +639,7 @@ class TestEntityClusterBot:
 
                 },
                 'block': {
-                    'number': 0,
+                    'number': block_number,
                     'timestamp': datetime.now().timestamp(),
                 },
                 'receipt': {

--- a/entity-cluster-bot/src/agent_test.py
+++ b/entity-cluster-bot/src/agent_test.py
@@ -218,7 +218,7 @@ class TestEntityClusterBot:
             })
 
         findings = agent.cluster_entities(w3, native_transfer1)
-        assert len(findings) == 2, "Findings should be returned as it is new account transfer"
+        assert len(findings) == 1, "Findings should be returned as it is new account transfer"
 
     def test_finding_onedirectional_initial_funds_new_account_above_threshold(self):
         TestEntityClusterBot.remove_persistent_state()


### PR DESCRIPTION
* In cases where txn's `value` is greater than `0`, add a nonce check for both sender and recipient. Create an additional edge if nonce check passes. Addresses txns [0x72aa08eab1ee164df0976a23c6fd911f4010e892e4d9f6c72b6ce6f42aeb160c](https://etherscan.io/tx/0x72aa08eab1ee164df0976a23c6fd911f4010e892e4d9f6c72b6ce6f42aeb160c) & [0x359113dec2f53bdb329e2bd82da2c9fc80f402a9d21a28ed8fae298da2dc4ca5](https://etherscan.io/tx/0x359113dec2f53bdb329e2bd82da2c9fc80f402a9d21a28ed8fae298da2dc4ca5)
* Was able to create alerts for this BSC txn: [0xd43d36fd266bcc971bbe7542e4028555a03398d09e097418f35d742c7d221cb4](https://bscscan.com/tx/0xd43d36fd266bcc971bbe7542e4028555a03398d09e097418f35d742c7d221cb4) without change to the bog logic. FN seems to be on the scanner side. While we could increase sharding, there are scanners that have zero dropped txns, so sharding may not completely address that.