### PR TITLE
Large Transfer Out Update 

### DIFF
--- a/large-transfer-out-py/package-lock.json
+++ b/large-transfer-out-py/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "large-transfer-out",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "large-transfer-out",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "hasInstallScript": true,
       "dependencies": {
         "forta-agent": "^0.1.48"

--- a/large-transfer-out-py/package.json
+++ b/large-transfer-out-py/package.json
@@ -1,6 +1,6 @@
 {
   "name": "large-transfer-out",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "displayName": "Large Transfer Out",
   "repository": "https://github.com/forta-network/starter-kits/tree/main/large-transfer-out-py",
   "description": "Bot identifies large native asset transfers that didn't exist X days ago",

--- a/large-transfer-out-py/src/agent.py
+++ b/large-transfer-out-py/src/agent.py
@@ -4,7 +4,7 @@ from forta_agent import Finding, FindingType, FindingSeverity, get_json_rpc_url,
 from web3 import Web3
 from bot_alert_rate import calculate_alert_rate, ScanCountType
 from src.storage import get_secrets
-from src.constants import THRESHOLDS, DAY_LOOKBACK_WINDOW, SWAP_TOPICS
+from src.constants import IGNORED_FUNCTION_SIGS, THRESHOLDS, DAY_LOOKBACK_WINDOW, SWAP_TOPICS
 
 SECRETS_JSON = get_secrets()
 
@@ -27,6 +27,9 @@ def detect_suspicious_native_transfers(w3, transaction_event: forta_agent.transa
     value = transaction_event.transaction.value
 
     if value >= THRESHOLDS[CHAIN_ID][1]:
+
+        if any(transaction_event.transaction.data.startswith(sig) for sig in IGNORED_FUNCTION_SIGS):
+            return findings
 
         # filter out any transactions that are swaps
         for log in transaction_event.logs:

--- a/large-transfer-out-py/src/agent_test.py
+++ b/large-transfer-out-py/src/agent_test.py
@@ -19,7 +19,8 @@ class TestLargeTransferOut:
                 'hash': "0",
                 'to': "0x1c5dCdd006EA78a7E4783f9e6021C32935a10fb4",
                 'from': ADDRESS_WITH_LARGE_BALANCE,
-                'value': "50000000000000000000"
+                'value': "50000000000000000000",
+                'data': '0x1234'
             },
             'block': {
                 'number': CURRENT_BLOCK
@@ -45,7 +46,9 @@ class TestLargeTransferOut:
                 'hash': tx.hash,
                 'to': tx.to,
                 'from': tx['from'],
-                'value': tx.value
+                'value': tx.value,
+                'data': '0x1234'
+
             },
             'block': {
                 'number': tx.blockNumber
@@ -62,7 +65,8 @@ class TestLargeTransferOut:
                 'hash': tx.hash,
                 'to': tx.to,
                 'from': tx['from'],
-                'value': tx.value
+                'value': tx.value,
+                'data': '0x1234'
             },
             'block': {
                 'number': tx.blockNumber
@@ -103,7 +107,8 @@ class TestLargeTransferOut:
                 'hash': tx.hash,
                 'to': tx.to,
                 'from': tx['from'],
-                'value': tx.value
+                'value': tx.value,
+                'data': '0x1234'
             },
             'block': {
                 'number': tx.blockNumber
@@ -123,7 +128,8 @@ class TestLargeTransferOut:
                 'hash': "0",
                 'to': "0x1c5dCdd006EA78a7E4783f9e6021C32935a10fb4",
                 'from': ADDRESS_WITHOUT_LARGE_BALANCE,
-                'value': "50000000000000000000"
+                'value': "50000000000000000000",
+                'data': '0x1234'
             },
             'block': {
                 'number': CURRENT_BLOCK
@@ -152,7 +158,8 @@ class TestLargeTransferOut:
                 'hash': "0",
                 'to': "0x1c5dCdd006EA78a7E4783f9e6021C32935a10fb4",
                 'from': ADDRESS_WITHOUT_LARGE_BALANCE,
-                'value': "50000000000000000000"
+                'value': "50000000000000000000",
+                'data': '0x1234'
             },
             'block': {
                 'number': CURRENT_BLOCK

--- a/large-transfer-out-py/src/constants.py
+++ b/large-transfer-out-py/src/constants.py
@@ -15,5 +15,5 @@ SWAP_TOPICS = ["0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d8
                "0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67",
                "0x19b47279256b2a23a1665c810c8d55a1758940ee09377d4f8d26497a3577dc83"]
 
-IGNORED_FUNCTION_SIGS = ["0xf305d719" # addLiquidityETH
-                         ]
+IGNORED_FUNCTION_SIGS = ["0xf305d719"] # addLiquidityETH
+                        

--- a/large-transfer-out-py/src/constants.py
+++ b/large-transfer-out-py/src/constants.py
@@ -10,6 +10,10 @@ THRESHOLDS = {1: (20000000000000000000, 50000000000000000000),  # mainnet - 20ET
               42161: (20000000000000000000, 50000000000000000000)  # arbitrum - 20ETH->50 ETH
               }
 
-# 0xd78ad95... is the swap topic for Uniswap v2 & 0xc42079f... is the swap topic for Uniswap v3
+# 0xd78ad95... is the swap topic for Uniswap v2, 0xc42079f... is the swap topic for Uniswap v3 and 0x19b4727... is the swap topic for PancakeSwap v3
 SWAP_TOPICS = ["0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822",
-               "0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67"]
+               "0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67",
+               "0x19b47279256b2a23a1665c810c8d55a1758940ee09377d4f8d26497a3577dc83"]
+
+IGNORED_FUNCTION_SIGS = ["0xf305d719" # addLiquidityETH
+                         ]


### PR DESCRIPTION
Ignores 1) Pancakeswap V3 Swaps, 2) `addLiquidityETH` function invocations