### PR TITLE
FP Mitigation Fix

### DIFF
--- a/scam-detector-py/package-lock.json
+++ b/scam-detector-py/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scam-detector-feed",
-  "version": "2.24.5",
+  "version": "2.24.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scam-detector-feed",
-      "version": "2.24.5",
+      "version": "2.24.6",
       "hasInstallScript": true,
       "dependencies": {
         "forta-agent": "^0.1.45"

--- a/scam-detector-py/package.json
+++ b/scam-detector-py/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scam-detector-feed",
   "displayName": "Scam Detector Feed",
-  "version": "2.24.5",
+  "version": "2.24.6",
   "repository": "https://github.com/forta-network/starter-kits/tree/main/scam-detector-py",
   "description": "Provides real-time intelligence on scammers engaged in over 10 unique scam types.",
   "longDescription": "The Scam Detector data feed provides real-time intelligence about EOAs, contracts and URLs involved in a variety of Web3 scams. It is jointly maintained by the Forta Foundation, Nethermind, Blocksec, ChainPatrol and members of the Forta developer community. It features market leading scam type coverage on ice phishing, address poisoning, rake tokens, token impersonation, fraudulent NFT orders, pig butchering, gas minting, sleep minting, hard rug pulls, soft rug pulls, and wash trading. Used by Web3 wallets, exchanges, crypto compliance companies and other Web3 security teams and tools. Teams can use Scam Detector labels to warn end-users during the pre-signing transaction approval process, to identify and prevent money laundering through regulated platforms, and to supplement existing blacklists among other use cases. Learn more in the documentation below, and request a free trial today.",

--- a/scam-detector-py/release.md
+++ b/scam-detector-py/release.md
@@ -1,6 +1,10 @@
 # Scam Detector Bot Release Notes
 
-## 2.24.4 (prod - 4/3/2024)
+## 2.24.6 (prod - 2/18/2025)
+
+- fix FP mitigation
+
+## 2.24.5 (prod - 4/3/2024)
 
 - removed ADDRESS-POISONING-FAKE-TOKEN alert
 

--- a/scam-detector-py/src/blockchain_indexer_service.py
+++ b/scam-detector-py/src/blockchain_indexer_service.py
@@ -112,7 +112,7 @@ class BlockChainIndexer:
     # Note, this doesnt work well with contracts; caller needs to check whether address is an EOA or not
     @staticmethod
     @RateLimiter(max_calls=1, period=1)
-    def get_contracts(address, chain_id, disable_etherscan=False, disable_zettablock=False) -> set:
+    def get_contracts(address, chain_id, disable_etherscan=False, disable_zettablock=True) -> set:
         logging.info(f"get_contracts for {address} on {chain_id} called.")
         contracts = set()
 


### PR DESCRIPTION
- Checks for labels regardless of the chain ID in the FP list
- Fetch existing labels even if chain id is null
- Remove check for `threat_category` and `address_type` in metadata to include old structure labels
- Disable Zettablock